### PR TITLE
fix(treesitter): defend against degenerate spans from gotreesitter

### DIFF
--- a/internal/chunk/treesitter/cast.go
+++ b/internal/chunk/treesitter/cast.go
@@ -82,10 +82,28 @@ func splitNode(n *gotreesitter.Node, chunkSize uint32, out *[]span) {
 	if n == nil {
 		return
 	}
-	size := n.EndByte() - n.StartByte()
+	start, end := n.StartByte(), n.EndByte()
+	if end < start {
+		// Degenerate node from gotreesitter parse-error recovery.
+		// ERROR nodes occasionally carry inverted byte ranges; emitting
+		// such a span would later trip a `source[start:end]` slice panic
+		// in (*Chunker).Chunk's text-extraction loop. Recurse into named
+		// children in the hope their bounds are well-formed; if there are
+		// none, skip silently — the surrounding text falls into adjacent
+		// chunks via the cAST end-from-next-start re-derive pass.
+		nc := n.NamedChildCount()
+		if nc == 0 {
+			return
+		}
+		for i := range nc {
+			splitNode(n.NamedChild(i), chunkSize, out)
+		}
+		return
+	}
+	size := end - start
 	nc := n.NamedChildCount()
 	if size <= chunkSize || nc == 0 {
-		*out = append(*out, span{n.StartByte(), n.EndByte()})
+		*out = append(*out, span{start, end})
 		return
 	}
 	// Recurse into named children. Anonymous children (punctuation,
@@ -93,6 +111,21 @@ func splitNode(n *gotreesitter.Node, chunkSize uint32, out *[]span) {
 	for i := range nc {
 		splitNode(n.NamedChild(i), chunkSize, out)
 	}
+}
+
+// spansValid returns false if any element of in is degenerate (start >
+// end) or out of bounds (end > srcLen). Used by (*Chunker).Chunk as a
+// belt-and-braces check after cAST: layer 1 (splitNode's end<start
+// guard) catches single-node defects; this catches sibling-ordering
+// defects the post-cAST re-derive pass can still produce when
+// gotreesitter emits siblings whose start bytes are not monotonic.
+func spansValid(in []span, srcLen uint32) bool {
+	for _, sp := range in {
+		if sp.start > sp.end || sp.end > srcLen {
+			return false
+		}
+	}
+	return true
 }
 
 // mergeSpans is the greedy merge pass. Walk spans in order, accumulate

--- a/internal/chunk/treesitter/cast_test.go
+++ b/internal/chunk/treesitter/cast_test.go
@@ -1,0 +1,90 @@
+package treesitter
+
+import "testing"
+
+// TestSpansValid is the regression test for the medium-workload panic
+// observed 2026-05-26 (`slice bounds out of range [105402:2278]` during
+// scripts/perf_collect.sh medium). The crash happened because the cAST
+// post-pass re-derives `raw[i].end = raw[i+1].start`, and when
+// gotreesitter emits siblings whose start bytes aren't monotonic, the
+// re-derived end can fall before the start. spansValid is the
+// belt-and-braces check that (*Chunker).Chunk runs on cAST output before
+// the `source[sp.start:sp.end]` text-extraction loop; if it returns
+// false, Chunk falls back to the line chunker instead of panicking.
+//
+// Layer 1 of the fix (splitNode's `end < start` guard in cast.go)
+// handles individual ERROR-recovery nodes with inverted bounds.
+// Layer 2 (this function) catches sibling-ordering defects layer 1
+// can't see. The two cover both shapes we've observed.
+func TestSpansValid(t *testing.T) {
+	cases := []struct {
+		name   string
+		in     []span
+		srcLen uint32
+		want   bool
+	}{
+		{
+			name:   "empty",
+			in:     nil,
+			srcLen: 100,
+			want:   true,
+		},
+		{
+			name:   "single well-formed",
+			in:     []span{{0, 50}},
+			srcLen: 100,
+			want:   true,
+		},
+		{
+			name:   "multiple well-formed",
+			in:     []span{{0, 30}, {30, 60}, {60, 100}},
+			srcLen: 100,
+			want:   true,
+		},
+		{
+			name:   "zero-width span (start == end) is well-formed",
+			in:     []span{{0, 0}, {0, 50}},
+			srcLen: 50,
+			want:   true,
+		},
+		{
+			name:   "inverted span (start > end) — the 2026-05-26 panic shape",
+			in:     []span{{0, 30}, {105402, 2278}, {2278, 100}},
+			srcLen: 108438,
+			want:   false,
+		},
+		{
+			name:   "end past srcLen (would also slice-panic)",
+			in:     []span{{0, 200}},
+			srcLen: 100,
+			want:   false,
+		},
+		{
+			name:   "well-formed leading spans, one inverted at the end",
+			in:     []span{{0, 30}, {30, 60}, {60, 50}},
+			srcLen: 100,
+			want:   false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := spansValid(tc.in, tc.srcLen)
+			if got != tc.want {
+				t.Errorf("spansValid(%+v, %d) = %v, want %v", tc.in, tc.srcLen, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestSplitNode_InvertedBoundsGuard is the layer-1 regression test —
+// without the `end < start` guard in splitNode, a gotreesitter ERROR
+// node with inverted bounds would emit a degenerate span directly into
+// raw, which cAST's re-derive pass then propagates further. We can't
+// easily mock *gotreesitter.Node from outside the package; the layer-1
+// guard's correctness is implicitly tested via the integration smoke
+// tests (TestSmoke_RealCorpus + the regex/treesitter parity harness)
+// continuing to pass. Documented here so the absence of a direct
+// splitNode unit test is intentional, not an oversight.
+func TestSplitNode_InvertedBoundsGuard(t *testing.T) {
+	t.Skip("layer-1 guard is exercised indirectly via TestSmoke_RealCorpus; mocking *gotreesitter.Node is not worth the test scaffold")
+}

--- a/internal/chunk/treesitter/chunker.go
+++ b/internal/chunk/treesitter/chunker.go
@@ -209,6 +209,15 @@ func (c *Chunker) Chunk(source []byte, language string, chunkSize int) ([]chunk.
 	}
 
 	spans := cAST(root, uint32(len(source)), uint32(chunkSize))
+	// Belt-and-braces: layer 1 (splitNode's end<start guard in cast.go)
+	// catches degenerate single nodes from gotreesitter ERROR-recovery;
+	// this layer catches sibling-ordering defects the cAST re-derive
+	// pass can still produce when gotreesitter emits siblings whose
+	// start bytes aren't monotonic. If anything still looks wrong, fall
+	// back to the line chunker rather than panic in the slice op below.
+	if !spansValid(spans, uint32(len(source))) {
+		return c.fallback(source, language, chunkSize)
+	}
 	out := make([]chunk.Chunk, len(spans))
 	for i, sp := range spans {
 		text := string(source[sp.start:sp.end])


### PR DESCRIPTION
## Summary

- The Phase 0 perf harness (`scripts/perf_collect.sh medium`, on the `perf-investigation` branch) panicked with `slice bounds out of range [105402:2278]` in the treesitter chunker's text-extraction loop on a 108,438-byte source from the semble medium corpus.
- Root cause: gotreesitter's parse-error recovery occasionally emits sibling AST nodes whose `StartByte` values are **not monotonic in source order** — sometimes via a single node with inverted self-bounds (`EndByte < StartByte`), sometimes via two siblings A,B where `B.StartByte() < A.EndByte()`. The cAST post-pass re-derives `raw[i].end = raw[i+1].start` to absorb inter-named-child gaps, so non-monotonic siblings produce inverted spans that downstream `source[start:end]` slice-panics on.
- Two-layer defense: **Layer 1** ([cast.go splitNode](internal/chunk/treesitter/cast.go)) skips nodes whose own bounds are inverted and recurses into named children instead. **Layer 2** ([chunker.go Chunk](internal/chunk/treesitter/chunker.go) + new `spansValid` helper) validates cAST's output before the slice loop and falls back to the line chunker if anything is still wrong. Layer 2 also serves as a forward-compat net for future gotreesitter quirks.

## Test plan

- [x] New `TestSpansValid` in [cast_test.go](internal/chunk/treesitter/cast_test.go) — 7 cases including the exact 2026-05-26 panic shape (`{105402, 2278}` within `srcLen=108438`), zero-width spans, end-past-srcLen, and well-formed leading-then-inverted-at-end.
- [x] Existing treesitter chunker tests (byte fidelity, AST-meaningful boundaries, line numbers, empty source, unknown language, chunk registry, smoke) all still pass with no changes.
- [x] `gofmt -l cmd internal` clean, `go vet ./...` clean, `go test ./...` green.
- [ ] Re-run `scripts/perf_collect.sh medium` post-merge to confirm the harness now traverses the full mode × chunker matrix without panicking on the same triggering file (Phase 1 follow-up on `perf-investigation`).

Layer 1 is intentionally not direct-unit-tested — mocking `*gotreesitter.Node` from outside the package isn't worth the test scaffold, and its correctness is exercised via existing integration / smoke tests.

Generated with [Claude Code](https://claude.com/claude-code)