### PR TITLE
perf(v0.8.4): paired heap refactor for ann.Flat.Query + bm25.Index.TopK

### DIFF
--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -30,6 +30,7 @@ ADR statuses: **Proposed** (documenting design alternatives; no implementation d
 | [ADR-022](#adr-022-rename-column--rename-constraint-folding-via-eager-application-v081-part-c) | RENAME COLUMN + RENAME CONSTRAINT folding via eager application (v0.8.1 Part C) | Accepted |
 | [ADR-023](#adr-023-gotreesitter-grammar_subset-machinery--binary-size-reduction-outcome-v082-investigation-outcome) | `gotreesitter` `grammar_subset` machinery + binary-size reduction outcome (v0.8.2 investigation outcome) | Accepted |
 | [ADR-024](#adr-024-pre-built-embedded-indices-for-mcprun-v083) | Pre-built embedded indices for `mcp.Run` (v0.8.3) | Accepted |
+| [ADR-026](#adr-026-paired-heap-refactor-for-annflatquery--bm25indextopk-v084) | Paired heap refactor for `ann.Flat.Query` + `bm25.Index.TopK` via shared `internal/topk` (v0.8.4) | Accepted |
 
 ---
 
@@ -1313,3 +1314,123 @@ Serialize the built `*search.Index` artifact (chunks slice + parallel embedding 
 - **No new third-party dependencies.** Custom binary serialization uses `encoding/binary`, `hash/crc32`, and the existing `io/fs` plumbing. The dep tree stays clean.
 
 - **v0.8.3 ready to tag after this lands.** Four-commit cadence on `v0.8.3-prebuilt-indices`: (1) serialize/deserialize primitives + walker prune, (2) `ken build-index` CLI subcommand, (3) `mcp.Run` auto-discovery + `Options.PrebuiltIndex`, (4) docs (this ADR + CHANGELOG + README + DESIGN.md). Closes [#10](https://github.com/townsendmerino/ken/issues/10).
+
+---
+
+## ADR-026: Paired heap refactor for `ann.Flat.Query` + `bm25.Index.TopK` (v0.8.4)
+
+**Status:** Accepted
+
+**Date:** 2026-05-26
+
+**Issue:** TBD (open a townsendmerino/ken issue for the v0.8.4 refactor + cross-link here on merge).
+
+**Extends:** ADR-025 perf-investigation outcome (currently in `outputs/adr-025-perf-investigation-outcome.md`, pending promotion to this file — ADR-026 references the empirical findings produced by that investigation).
+
+### Context
+
+[ADR-025](outputs/adr-025-perf-investigation-outcome.md)'s medium-scale (semble bench corpus, 378,524 chunks) CPU profile surfaced two adjacent hotspots that share the same structural defect:
+
+- **`ann.Flat.Query` is 78.56% of hybrid-regex search CPU at medium**, and **30.88% of that is `sort.Slice`** sorting all 378k candidate cosine-similarity scores to take K=10. Top-K-of-N via full sort is O(N log N).
+- **`bm25.Index.TopK` is 36% of bm25-regex search CPU at medium**, all in `sort.Slice` / `sort.pdqsort_func` / `sort.partition_func` over the positive-score candidate list. Same O(N log N) pattern.
+
+Both code paths use the same anti-pattern: score every candidate into a slice, sort by score descending, take the first K. Top-K via min-heap of size K is the canonical fix — O(N log K), which at K=10 and N=378k is roughly 50× cheaper in the asymptotic bound and produces the same K items in the same order (ties handled identically when the caller iterates input in natural index order, which both call sites do).
+
+The refactors are mechanically identical and ship together as a single PR + single ADR. The heap is shared via a new `internal/topk` leaf package so a future caller (a reranker, a `find_related` re-implementation, etc.) doesn't have to re-derive the same primitive.
+
+### Decision
+
+Replace sort-then-slice with min-heap-of-size-K in `ann.Flat.Query` and `bm25.Index.TopK`, sharing a new `internal/topk` package.
+
+**Three surfaces:**
+
+1. **`internal/topk` package** (NEW, leaf). Generic `Selector[T any]` with capacity K. `Push(item, score) bool` (strict `>` on at-capacity replace — see tie-breaking below); `Result() []ItemWithScore[T]` returns descending by score; `Len() int`. Hand-rolled `siftUp` / `siftDown` rather than `container/heap` because `heap.Interface` takes `interface{}` and would force boxing — defeating the perf goal.
+
+2. **`ann.Flat.Query` two-path refactor.** `k<=0 || k>=Len` keeps the existing full-sort path (preserves the documented "return all, sorted" escape hatch); `0 < k < Len` takes the heap. A `sort.SliceStable` at the end of the heap path imposes the documented ascending-Index tie-break that the heap on its own doesn't guarantee (K-sized stable sort is O(K log K), cheap at K=10).
+
+3. **`bm25.Index.TopK` two-path refactor.** `k<0` keeps the full-sort path (the original `if k >= 0 && k < len(res)` truncation gate's escape hatch); `k>=0` takes the heap. `k=0` selector returns empty, matching the original gate's k=0 behavior. Same `sort.SliceStable` tie-break for ascending Doc id.
+
+**Tie-breaking design.** The heap's `Push` uses strict `>` (not `>=`) on at-capacity replace, meaning a new item tying the current minimum's score is **discarded**. Both call sites iterate input in their natural index order (`for i, v := range f.vecs` / `for d, s := range scores`), so the first-seen-of-tied-group is naturally the smaller-index one — which the heap retains. The final `sort.SliceStable` re-orders any ties within the K result by ascending secondary key for deterministic output that matches the pre-refactor public contract.
+
+### Alternatives considered
+
+- **Quickselect / `container/heap` without a generic wrapper.** Rejected for code-template-reuse reasons. The two callers want the same primitive; sharing a small generic package keeps the heap logic in one place + lets future callers reuse it without re-deriving heap correctness. `container/heap` specifically also has the `interface{}` boxing problem ([ADR-001](#adr-001-pure-go-no-cgo)'s pure-Go-no-cgo discipline argues for letting generics handle this — Go 1.26 is the project's toolchain pin, generics are fully available).
+
+- **Partial sort.** Rejected because Go's stdlib doesn't have one. Implementing a partial sort would be more code than the min-heap, with no compensating benefit.
+
+- **Custom min-heap inlined in each caller.** Rejected for DRY. The heap logic is small but non-trivial (siftUp/siftDown correctness, tie-breaking semantics, the K-sized stable sort at the end). Duplicating it in `internal/ann` and `internal/bm25` would also duplicate the test surface and the future-maintenance burden.
+
+- **Pure-Go HNSW** (replacement for ANN flat). Rejected for v0.8.4 scope; documented future work in [docs/DESIGN.md §10](DESIGN.md#10-risk-register) and ADR-025 hotspot #6. The trigger to revisit: real user reports search latency on a 100k+ chunk corpus as actionable pain, OR a pure-Go HNSW dep emerges that meets the no-cgo bar with good maintenance signal. The heap refactor is complementary to eventual HNSW (every search algorithm needs a top-K selector); landing it now is not the same kind of work.
+
+- **Placing `topk` at `internal/search/topk`** rather than the standalone leaf `internal/topk`. Considered. Rejected because the heap utility has no business knowing about search internals; a future reranker or `find_related` re-implementation needing top-K shouldn't have to import from the search subsystem. Standalone leaf placement keeps the dependency direction one-way (concrete subsystems depend on the primitive, not the reverse).
+
+- **Push returns `bool` vs no return value.** Kept the bool return per the briefing. Rare but useful for callers that want to short-circuit expensive scoring on items that obviously won't make the cut (e.g., score = 0). Not applicable to the two production callers today; cheap to expose now if a future caller needs it.
+
+### Consequences
+
+**Measured impact** (Apple M1 Pro / Go 1.26.3 / darwin/arm64 / `CGO_ENABLED=0 -trimpath -ldflags='-s -w'`):
+
+- **`ann.Flat.Query` micro-benchmark** (`go test -bench BenchmarkFlatQuery -benchmem -count=10`, before = perf-investigation HEAD with sort-based code, after = this commit):
+
+  ```
+                   │ sort-based       │  heap-based                     │
+                   │   sec/op         │   sec/op       vs sort          │
+  FlatQuery/N1k    │ 182.3µs ± 1%     │ 103.2µs ± 1%   −43.4% (p=0.000) │
+  FlatQuery/N10k   │ 2.253ms ± 1%     │ 990.2µs ± 1%   −56.1% (p=0.000) │
+  FlatQuery/N50k   │ 12.297ms ± 1%    │ 4.926ms ± 0%   −59.9% (p=0.000) │
+
+                   │ B/op             │  B/op          vs sort          │
+  FlatQuery/N1k    │ 16,472 ± 0%      │ 728 ± 0%       −95.6% (p=0.000) │
+  FlatQuery/N10k   │ 163,928 ± 0%     │ 728 ± 0%       −99.6% (p=0.000) │
+  FlatQuery/N50k   │ 802,904 ± 0%     │ 728 ± 0%       −99.9% (p=0.000) │
+  ```
+
+- **`bm25.Index.TopK` micro-benchmark** (via `BenchmarkScore` which is dominated by TopK; same harness):
+
+  ```
+                   │ sort-based       │  heap-based                     │
+                   │   sec/op         │   sec/op       vs sort          │
+  Score/N100       │ 3.934µs ± 2%     │ 1.099µs ± 1%   −72.1% (p=0.000) │
+  Score/N1000      │ 8.782µs ± 2%     │ 1.995µs ± 1%   −77.3% (p=0.000) │
+
+                   │ B/op             │  B/op          vs sort          │
+  Score/N100       │ 2,711 ± 0%       │ 1,586 ± 0%     −41.5% (p=0.000) │
+  Score/N1000      │ 15,961 ± 0%      │ 5,961 ± 0%     −62.7% (p=0.000) │
+  ```
+
+- **End-to-end medium-corpus search latency** (`scripts/perf_collect.sh medium --modes=bm25,hybrid --chunkers=regex`, 1000 queries / k=10 against a warm 378,524-chunk semble medium index):
+
+  | combo | metric | sort-based | heap-based | Δ |
+  |---|---|---|---|---|
+  | bm25-regex SEARCH | p50 | 11.5 ms | **1.88 ms** | **−83.7%** |
+  | bm25-regex SEARCH | p95 | 23.2 ms | 5.14 ms | −77.8% |
+  | bm25-regex SEARCH | p99 | 31.4 ms | 20.58 ms | −34.5% |
+  | bm25-regex SEARCH | allocs/q | 8.7 MB | 2.89 MB | −66.8% |
+  | hybrid-regex SEARCH | p50 | 193 ms | **113.2 ms** | **−41.4%** |
+  | hybrid-regex SEARCH | p95 | 214 ms | 124 ms | −42.1% |
+  | hybrid-regex SEARCH | p99 | 391 ms | 141 ms | −64.0% |
+  | hybrid-regex SEARCH | allocs/q | 14.5 MB | 2.98 MB | −79.4% |
+
+  The hybrid p50 result hits the upper end of ADR-025's 25-40% projection; bm25 search came in well above projection because TopK was a larger fraction of bm25 search CPU than ann flat is of hybrid search CPU. **Index times unchanged** (bm25 index 55s → 59s, hybrid index 178s → 182s — within noise; the refactor only touches the search path, not indexing).
+
+- **NDCG@10 safety check** (semble bench corpus, 63 repos / 1251 tasks, all 3 modes, `--chunker regex` both sides for clean apples-to-apples):
+
+  | mode | sort-based NDCG@10 | heap-based NDCG@10 | Δ |
+  |---|---|---|---|
+  | bm25 | 0.6237 | 0.6237 | **0.0000** (exact) |
+  | semantic | 0.6469 | 0.6469 | **0.0000** (exact) |
+  | hybrid | 0.8418 | 0.8418 | **0.0000** (exact) |
+
+  Exact match in all three modes confirms the top-K determinism claim. The heap refactor changes search *latency*, not search *results* — the K items emerging in the K positions are identical. NDCG-bench wall times are dominated by per-repo index build (unchanged by this refactor) and vary within noise from machine load; the relevant signal is the NDCG@10 value, not the wall time.
+
+- **`internal/topk` is reusable.** A future caller (the rerank pipeline if/when it becomes hot at small scale per ADR-025 hotspot #7's small-scale finding; a `find_related` re-implementation; etc.) can take a dependency without re-deriving the heap correctness invariants.
+
+- **Net allocations per call go up by 3** (4 → 7 for ann, 5 → 8 for bm25). That's the `Selector` + result slice + scratch slice overhead. The aggregate *bytes* allocated drops by orders of magnitude because the full N-sized candidate slice is gone. Net GC pressure drops dramatically — visible as the per-query alloc bytes collapse in the end-to-end table above.
+
+- **No public API changes.** Both `ann.Flat.Query` and `bm25.Index.TopK` keep their existing signatures + documented tie-breaking semantics. Existing callers (`search.hybridSearch`, the rerank pipeline, etc.) integrate unchanged.
+
+- **No new third-party dependencies.** `internal/topk` is standard-library-only.
+
+- **Two-commit PR shape.** Commit 1 lands `internal/topk` + tests + micro-benchmark; commit 2 lands the two refactors + this ADR-026. Reviewers see the new utility in isolation before reading the integrations.
+
+- **Future perf work informed.** The remaining ADR-025 hotspots (BM25 tokenizer allocs at ~45% of indexing allocs, embed `weightedMeanPoolSafe` accumulator) will ship in subsequent rolling point releases (v0.8.5+) as the analysis from this work feeds back into the prioritization. Specifically, with search latency cut as documented above, the embed inference cost becomes a proportionally larger fraction of cold-start time on the giant-corpus workload that the planning Claude's Phase 1 medium re-run will benchmark next.

--- a/internal/ann/ann_bench_test.go
+++ b/internal/ann/ann_bench_test.go
@@ -1,0 +1,75 @@
+package ann
+
+import (
+	"math"
+	"math/rand/v2"
+	"testing"
+)
+
+// dimForBench matches Model2Vec's potion-code-16M output dimension.
+// Synthetic vectors at this width keep the benchmark realistic relative
+// to what ken's embed pipeline actually feeds Flat in production.
+const dimForBench = 128
+
+// makeUnitVectors generates n L2-normalized random vectors of dim d
+// using a seeded PRNG. Determinism: same (n, d, seed) → identical
+// vectors, so benchstat compares across runs cleanly.
+//
+// The Flat type's invariant (vectors must be L2-normalized) is enforced
+// at the embed boundary in production; we honour it here so the
+// benchmark exercises the same code path the production retriever does.
+func makeUnitVectors(n, d int, seed uint64) [][]float32 {
+	rng := rand.New(rand.NewPCG(seed, seed^0xdeadbeef))
+	out := make([][]float32, n)
+	for i := range out {
+		v := make([]float32, d)
+		var sumsq float64
+		for j := range v {
+			x := float32(rng.NormFloat64())
+			v[j] = x
+			sumsq += float64(x) * float64(x)
+		}
+		inv := float32(1.0 / math.Sqrt(sumsq))
+		for j := range v {
+			v[j] *= inv
+		}
+		out[i] = v
+	}
+	return out
+}
+
+func BenchmarkFlatQuery(b *testing.B) {
+	// N values per the briefing: prediction #3 says flat search becomes
+	// intractable at chromium-scale (~millions of chunks). The per-N
+	// curve here lets a Phase-1 benchstat run trace the O(N·D) line and
+	// pick a hand-off threshold for HNSW (DESIGN.md §10 future work).
+	//
+	// Max N is 50k rather than the briefing's 100k — judgment call #3,
+	// dropping to keep a single bench iteration under a couple seconds
+	// on this laptop. Phase 1 can bump back to 100k if the harness lives
+	// on better hardware.
+	cases := []struct {
+		name string
+		n    int
+	}{
+		{"N1k", 1_000},
+		{"N10k", 10_000},
+		{"N50k", 50_000},
+	}
+	for _, tc := range cases {
+		b.Run(tc.name, func(b *testing.B) {
+			corpus := makeUnitVectors(tc.n, dimForBench, 0xfeed)
+			query := makeUnitVectors(1, dimForBench, 0xdade)[0]
+			f := New(corpus)
+			// SetBytes is the per-iteration work: N vectors × dim × 4 B
+			// (float32 dot products). benchstat MB/s then reads as
+			// flat-scan memory bandwidth.
+			b.SetBytes(int64(tc.n) * int64(dimForBench) * 4)
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				_ = f.Query(query, 10)
+			}
+		})
+	}
+}

--- a/internal/ann/flat.go
+++ b/internal/ann/flat.go
@@ -28,7 +28,11 @@
 //     containing search.Index can be swapped wholesale between queries.
 package ann
 
-import "sort"
+import (
+	"sort"
+
+	"github.com/townsendmerino/ken/internal/topk"
+)
 
 // Hit is one scored item, highest Score (cosine similarity) first.
 type Hit struct {
@@ -57,8 +61,47 @@ func (f *Flat) Len() int { return len(f.vecs) }
 // Query returns the k highest cosine-similarity vectors to q, descending,
 // ties broken by ascending index for determinism. k<=0 or k>=Len returns
 // all, sorted.
+//
+// Two paths by design:
+//
+//   - k<=0 || k>=Len: full sort over every dot-product result. Preserves
+//     the documented "return all, sorted" semantic for callers that want
+//     the complete ranked list.
+//   - 0 < k < Len: min-heap of size K via internal/topk. O(N log K) vs
+//     the full-sort path's O(N log N) — at medium scale (~378k chunks,
+//     k=10) this was 30.88% of hybrid search CPU per ADR-025. Final
+//     sort.SliceStable imposes the ascending-Index tie-break the doc
+//     comment promises, which the heap on its own doesn't guarantee
+//     (heap only sorts by score; ties within result come out in
+//     heap-internal order). The K-sized stable sort is O(K log K) —
+//     cheap at K=10.
 func (f *Flat) Query(q []float32, k int) []Hit {
-	hits := make([]Hit, 0, len(f.vecs))
+	// Full-sort path: k<=0 returns everything; k>=Len would have nothing
+	// to discard anyway. Either way the heap buys us nothing.
+	if k <= 0 || k >= len(f.vecs) {
+		hits := make([]Hit, 0, len(f.vecs))
+		for i, v := range f.vecs {
+			if len(v) != len(q) {
+				continue // dimension mismatch ⇒ skip rather than panic
+			}
+			var dot float64
+			for j := range v {
+				dot += float64(v[j]) * float64(q[j])
+			}
+			hits = append(hits, Hit{Index: i, Score: dot})
+		}
+		sort.Slice(hits, func(a, b int) bool {
+			if hits[a].Score != hits[b].Score {
+				return hits[a].Score > hits[b].Score
+			}
+			return hits[a].Index < hits[b].Index
+		})
+		return hits
+	}
+
+	// Heap path: 0 < k < Len. Score every vector, push into the K-sized
+	// min-heap; the heap only retains the K highest seen so far.
+	sel := topk.New[int](k)
 	for i, v := range f.vecs {
 		if len(v) != len(q) {
 			continue // dimension mismatch ⇒ skip rather than panic
@@ -67,16 +110,20 @@ func (f *Flat) Query(q []float32, k int) []Hit {
 		for j := range v {
 			dot += float64(v[j]) * float64(q[j])
 		}
-		hits = append(hits, Hit{Index: i, Score: dot})
+		sel.Push(i, dot)
 	}
-	sort.Slice(hits, func(a, b int) bool {
-		if hits[a].Score != hits[b].Score {
-			return hits[a].Score > hits[b].Score
+	items := sel.Result() // descending by score; tie order is heap-internal
+	// Stable secondary sort by ascending Index to honor the doc-comment
+	// tie-break contract. K is small (typically 10), so this is cheap.
+	sort.SliceStable(items, func(a, b int) bool {
+		if items[a].Score != items[b].Score {
+			return items[a].Score > items[b].Score
 		}
-		return hits[a].Index < hits[b].Index
+		return items[a].Item < items[b].Item
 	})
-	if k > 0 && k < len(hits) {
-		hits = hits[:k]
+	hits := make([]Hit, len(items))
+	for j, s := range items {
+		hits[j] = Hit{Index: s.Item, Score: s.Score}
 	}
 	return hits
 }

--- a/internal/bm25/bm25_bench_test.go
+++ b/internal/bm25/bm25_bench_test.go
@@ -1,0 +1,89 @@
+package bm25
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// loadRealSource reads a real Go source file from this repo. The choice
+// is deliberate — ken's own internal/search/index.go is checked in,
+// non-trivial in size, exercises camelCase / snake_case / digit-bearing
+// identifiers, and would never be missing on a developer machine.
+// Skips if not found (so benchmarks don't fail in an unusual checkout).
+func loadRealSource(b *testing.B) string {
+	b.Helper()
+	// internal/bm25 → ../search/index.go from this file's CWD when go test
+	// runs (CWD = package dir, by Go test convention).
+	path := filepath.Join("..", "search", "index.go")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		b.Skipf("real source not found at %s: %v", path, err)
+	}
+	return string(data)
+}
+
+func BenchmarkTokenize(b *testing.B) {
+	src := loadRealSource(b)
+	b.SetBytes(int64(len(src)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = Tokenize(src)
+	}
+}
+
+// buildBenchCorpus builds a synthetic N-document corpus from a single
+// real source file by splitting it into roughly equal line-count chunks.
+// Each "document" is the chunk's lines re-joined with newlines, then
+// tokenized. Deterministic; same input always produces the same corpus.
+func buildBenchCorpus(src string, numDocs int) [][]string {
+	lines := strings.Split(src, "\n")
+	if numDocs <= 0 {
+		numDocs = 1
+	}
+	per := len(lines) / numDocs
+	if per < 1 {
+		per = 1
+	}
+	docs := make([][]string, 0, numDocs)
+	for i := 0; i < numDocs && i*per < len(lines); i++ {
+		end := (i + 1) * per
+		if end > len(lines) {
+			end = len(lines)
+		}
+		chunk := strings.Join(lines[i*per:end], "\n")
+		docs = append(docs, Tokenize(chunk))
+	}
+	return docs
+}
+
+func BenchmarkScore(b *testing.B) {
+	src := loadRealSource(b)
+	// Table-driven: small / medium corpus. The 1000-doc size is the
+	// briefing's prediction-#2-falsification target; the 100-doc size
+	// provides a fast inner-loop variant.
+	cases := []struct {
+		name string
+		n    int
+	}{
+		{"N100", 100},
+		{"N1000", 1000},
+	}
+	query := Tokenize("index search build chunks")
+	for _, tc := range cases {
+		b.Run(tc.name, func(b *testing.B) {
+			corpus := buildBenchCorpus(src, tc.n)
+			if len(corpus) == 0 {
+				b.Skipf("corpus build produced 0 docs for N=%d", tc.n)
+			}
+			ix := Build(corpus)
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				_ = ix.TopK(query, 10)
+			}
+		})
+	}
+}

--- a/internal/bm25/query.go
+++ b/internal/bm25/query.go
@@ -3,6 +3,8 @@ package bm25
 import (
 	"math"
 	"sort"
+
+	"github.com/townsendmerino/ken/internal/topk"
 )
 
 // Result is one scored document, highest Score first.
@@ -51,22 +53,61 @@ func (ix *Index) Scores(query []string) []float64 {
 
 // TopK returns the k highest-scoring documents with Score > 0, ties broken
 // by ascending document id so results are deterministic.
+//
+// Two paths by design:
+//
+//   - k<0: full sort over every scoring doc. Preserves the "no truncation"
+//     escape hatch the original `if k >= 0 && k < len(res)` gate exposed
+//     to callers that want every positive-scored document.
+//   - k>=0: min-heap of size K via internal/topk. O(N log K) vs the
+//     full-sort path's O(N log N). At medium scale (~378k chunks, k=10)
+//     this was 36% of bm25 search CPU per ADR-025. Final sort.SliceStable
+//     imposes the ascending-Doc tie-break the doc comment promises,
+//     which the heap on its own doesn't guarantee. K-sized stable sort
+//     is O(K log K) — cheap at K=10. k=0 returns an empty slice (topk
+//     with cap 0 always discards), matching the prior `k=0 → empty`
+//     behavior from the original truncation gate.
 func (ix *Index) TopK(query []string, k int) []Result {
 	scores := ix.Scores(query)
-	res := make([]Result, 0, len(scores))
+
+	// Full-sort path: k<0 means "no truncation, return everything".
+	if k < 0 {
+		res := make([]Result, 0, len(scores))
+		for d, s := range scores {
+			if s > 0 {
+				res = append(res, Result{Doc: d, Score: s})
+			}
+		}
+		sort.Slice(res, func(i, j int) bool {
+			if res[i].Score != res[j].Score {
+				return res[i].Score > res[j].Score
+			}
+			return res[i].Doc < res[j].Doc
+		})
+		return res
+	}
+
+	// Heap path: k>=0. Push every positive-scored doc; the heap retains
+	// the K highest. k=0 selector discards everything → empty result,
+	// matching the prior gate's k=0 behavior.
+	sel := topk.New[int](k)
 	for d, s := range scores {
 		if s > 0 {
-			res = append(res, Result{Doc: d, Score: s})
+			sel.Push(d, s)
 		}
 	}
-	sort.Slice(res, func(i, j int) bool {
-		if res[i].Score != res[j].Score {
-			return res[i].Score > res[j].Score
+	items := sel.Result()
+	// Stable secondary sort by ascending Doc id to honor the doc-comment
+	// tie-break contract.
+	sort.SliceStable(items, func(a, b int) bool {
+		if items[a].Score != items[b].Score {
+			return items[a].Score > items[b].Score
 		}
-		return res[i].Doc < res[j].Doc
+		return items[a].Item < items[b].Item
 	})
-	if k >= 0 && k < len(res) {
-		res = res[:k]
+	out := make([]Result, len(items))
+	for j, s := range items {
+		out[j] = Result{Doc: s.Item, Score: s.Score}
 	}
-	return res
+	return out
 }

--- a/internal/topk/topk.go
+++ b/internal/topk/topk.go
@@ -1,0 +1,167 @@
+// Package topk is a min-heap-of-size-K selector for "keep the K
+// highest-scoring items from a stream" without sorting the full input.
+// O(N log K) vs sort.Slice's O(N log N); the win grows with N relative
+// to K.
+//
+// Use in place of "score everything into a slice, sort by score
+// descending, take the first K" — a pattern that's invisible at toy
+// scale but dominates search CPU at production scale (per ADR-025).
+//
+// The implementation hand-rolls heap up/down rather than wrapping
+// container/heap because (a) container/heap takes interface{} via
+// heap.Interface which would force boxing and defeat the perf goal,
+// and (b) the heap-of-fixed-K pattern is small enough that direct
+// implementation is clearer than the heap.Interface dance.
+//
+// Generics over interface{}: ken is on Go 1.26 (go.mod toolchain pin),
+// so generics are fully available. Generic typing avoids the boxing
+// allocations that interface{} would impose and avoids per-callsite
+// concrete-type copies. The two production callers (internal/ann.Flat.Query
+// and internal/bm25.Index.TopK) use different item types, so generics
+// are the right shape.
+//
+// Placement decision (ADR-026 alternatives): standalone leaf at
+// internal/topk rather than internal/search/topk. If a future caller
+// (a reranker, a find_related reimplementation, etc.) needs top-K
+// selection, the import path doesn't suggest false coupling to BM25
+// or ANN.
+package topk
+
+// scored is the internal heap element: an item plus its score. Kept
+// non-generic-friendly (struct-of-T) so the slice backing the heap
+// is contiguous and benefits from CPU-cache locality on the up/down
+// sift loops.
+type scored[T any] struct {
+	item  T
+	score float64
+}
+
+// Selector is a min-heap of fixed capacity. Push items as you score
+// them; the heap retains the K highest-scoring observations seen so
+// far. Read via Result() — returned in descending-score order.
+//
+// Tie-breaking: a strict greater-than comparison in Push ensures that
+// when a new item ties the current minimum's score, the new item is
+// discarded and the older one stays. Callers that iterate input in
+// some natural order (ascending index, etc.) thereby inherit a stable
+// "first-seen wins on tie" behavior without paying a secondary-key
+// sort cost.
+type Selector[T any] struct {
+	k    int
+	heap []scored[T]
+}
+
+// New returns a Selector that keeps the top k items by score.
+// k=0 is valid (Result returns an empty slice; Push always discards).
+// Negative k panics — caller error, not a runtime condition.
+func New[T any](k int) *Selector[T] {
+	if k < 0 {
+		panic("topk.New: k must be non-negative")
+	}
+	return &Selector[T]{
+		k:    k,
+		heap: make([]scored[T], 0, k),
+	}
+}
+
+// Push offers (item, score) to the selector. If the heap hasn't reached
+// capacity, item is added. Otherwise item replaces the current minimum
+// iff score > min_score (strict; ties favor the older item per the
+// tie-breaking note above). Returns true if item was retained, false
+// if discarded.
+func (s *Selector[T]) Push(item T, score float64) bool {
+	if s.k == 0 {
+		return false
+	}
+	if len(s.heap) < s.k {
+		s.heap = append(s.heap, scored[T]{item: item, score: score})
+		s.siftUp(len(s.heap) - 1)
+		return true
+	}
+	// At capacity: only retain if strictly greater than current minimum.
+	// Strict > preserves "older wins on tie" for callers that iterate
+	// input in their natural order — see the doc comment on Selector.
+	if score <= s.heap[0].score {
+		return false
+	}
+	s.heap[0] = scored[T]{item: item, score: score}
+	s.siftDown(0)
+	return true
+}
+
+// ItemWithScore is the public read shape returned by Result.
+type ItemWithScore[T any] struct {
+	Item  T
+	Score float64
+}
+
+// Result returns the retained items in descending-score order. May be
+// shorter than k if Push was called fewer than k times. Returned slice
+// is freshly allocated; safe for callers to retain or mutate.
+//
+// Sort cost is O(K log K) — by construction K is small (typically 10
+// for ken's search), so this is cheap relative to the N pushes that
+// fed the heap.
+//
+// Tie-breaking on Result: the heap's internal ordering on ties is not
+// defined, but because Push uses strict > (see Push comment), the
+// retained K items at the tie boundary are the first-seen of any tied
+// group. Result then sorts strictly by score; equal-score items emerge
+// in heap-internal order, which is deterministic for a given input
+// sequence but not lexically ordered by item.
+func (s *Selector[T]) Result() []ItemWithScore[T] {
+	out := make([]ItemWithScore[T], len(s.heap))
+	// Repeated extract-min would give ascending order — we reverse-fill
+	// the output slice to land descending without a second pass.
+	n := len(s.heap)
+	tmp := make([]scored[T], n)
+	copy(tmp, s.heap)
+	for i := n - 1; i >= 0; i-- {
+		min := tmp[0]
+		tmp[0] = tmp[len(tmp)-1]
+		tmp = tmp[:len(tmp)-1]
+		siftDownSlice(tmp, 0)
+		out[i] = ItemWithScore[T]{Item: min.item, Score: min.score}
+	}
+	return out
+}
+
+// Len is the current number of retained items (0 ≤ Len() ≤ k).
+func (s *Selector[T]) Len() int { return len(s.heap) }
+
+// ── heap operations ───────────────────────────────────────────────
+// Min-heap: parent ≤ children. heap[0] is the smallest score.
+
+func (s *Selector[T]) siftUp(i int) {
+	for i > 0 {
+		parent := (i - 1) / 2
+		if s.heap[i].score >= s.heap[parent].score {
+			return
+		}
+		s.heap[i], s.heap[parent] = s.heap[parent], s.heap[i]
+		i = parent
+	}
+}
+
+func (s *Selector[T]) siftDown(i int) { siftDownSlice(s.heap, i) }
+
+// siftDownSlice is shared by Selector.siftDown and Result's
+// extract-min loop (which operates on a scratch slice).
+func siftDownSlice[T any](heap []scored[T], i int) {
+	n := len(heap)
+	for {
+		l, r := 2*i+1, 2*i+2
+		smallest := i
+		if l < n && heap[l].score < heap[smallest].score {
+			smallest = l
+		}
+		if r < n && heap[r].score < heap[smallest].score {
+			smallest = r
+		}
+		if smallest == i {
+			return
+		}
+		heap[i], heap[smallest] = heap[smallest], heap[i]
+		i = smallest
+	}
+}

--- a/internal/topk/topk_bench_test.go
+++ b/internal/topk/topk_bench_test.go
@@ -1,0 +1,46 @@
+package topk
+
+import (
+	"math/rand/v2"
+	"testing"
+)
+
+// BenchmarkSelector confirms the O(N log K) scaling claim at the unit
+// level before the two integrators (internal/ann, internal/bm25) take
+// dependencies. Table-driven across N to make the per-N curve visible
+// in benchstat output; K=10 matches ken's production search K.
+//
+// Deterministic input: seeded PCG so the same (N, K, seed) always
+// produces the same input sequence — benchstat diffs across runs stay
+// signal, not noise.
+func BenchmarkSelector(b *testing.B) {
+	const k = 10
+	cases := []struct {
+		name string
+		n    int
+	}{
+		{"N1k", 1_000},
+		{"N10k", 10_000},
+		{"N100k", 100_000},
+	}
+	for _, tc := range cases {
+		b.Run(tc.name, func(b *testing.B) {
+			// Pre-generate the score stream so the per-iteration work
+			// is just the heap operations, not the PRNG.
+			rng := rand.New(rand.NewPCG(0xc0ffee, 0xfeedface))
+			scores := make([]float64, tc.n)
+			for i := range scores {
+				scores[i] = rng.Float64()
+			}
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				sel := New[int](k)
+				for j, sc := range scores {
+					sel.Push(j, sc)
+				}
+				_ = sel.Result()
+			}
+		})
+	}
+}

--- a/internal/topk/topk_test.go
+++ b/internal/topk/topk_test.go
@@ -1,0 +1,172 @@
+package topk
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestNew_ZeroK(t *testing.T) {
+	s := New[int](0)
+	if got := s.Push(1, 1.0); got {
+		t.Errorf("Push(1, 1.0) on k=0 selector = true, want false")
+	}
+	if r := s.Result(); len(r) != 0 {
+		t.Errorf("Result() on k=0 selector = %v, want empty", r)
+	}
+	if s.Len() != 0 {
+		t.Errorf("Len() = %d, want 0", s.Len())
+	}
+}
+
+func TestNew_NegativeK_Panics(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("New[int](-1) did not panic")
+		}
+	}()
+	_ = New[int](-1)
+}
+
+func TestPush_UnderCapacity(t *testing.T) {
+	s := New[int](10)
+	for i := 0; i < 5; i++ {
+		if !s.Push(i, float64(i)) {
+			t.Errorf("Push(%d) under-capacity returned false, want true", i)
+		}
+	}
+	if s.Len() != 5 {
+		t.Errorf("Len() = %d, want 5", s.Len())
+	}
+	result := s.Result()
+	if len(result) != 5 {
+		t.Fatalf("Result() len = %d, want 5", len(result))
+	}
+	// Descending by score: scores 4,3,2,1,0
+	for i, r := range result {
+		want := float64(4 - i)
+		if r.Score != want {
+			t.Errorf("Result[%d].Score = %v, want %v", i, r.Score, want)
+		}
+	}
+}
+
+func TestPush_AtCapacity_HigherScoreReplaces(t *testing.T) {
+	s := New[string](3)
+	s.Push("a", 1)
+	s.Push("b", 2)
+	s.Push("c", 3)
+	if !s.Push("d", 4) {
+		t.Error("Push(d, 4) at-cap with score above min returned false, want true")
+	}
+	result := s.Result()
+	gotItems := []string{result[0].Item, result[1].Item, result[2].Item}
+	wantItems := []string{"d", "c", "b"}
+	if !reflect.DeepEqual(gotItems, wantItems) {
+		t.Errorf("Result items = %v, want %v", gotItems, wantItems)
+	}
+}
+
+func TestPush_AtCapacity_LowerScoreDiscarded(t *testing.T) {
+	s := New[string](3)
+	s.Push("a", 1)
+	s.Push("b", 2)
+	s.Push("c", 3)
+	if s.Push("d", 0) {
+		t.Error("Push(d, 0) at-cap with score below min returned true, want false")
+	}
+	result := s.Result()
+	gotItems := []string{result[0].Item, result[1].Item, result[2].Item}
+	wantItems := []string{"c", "b", "a"}
+	if !reflect.DeepEqual(gotItems, wantItems) {
+		t.Errorf("Result items = %v, want %v", gotItems, wantItems)
+	}
+}
+
+func TestPush_AtCapacity_TiedScoreDiscarded(t *testing.T) {
+	// Strict > in Push means a new item tying the current minimum's
+	// score does NOT replace it. The older item stays. This is
+	// load-bearing for callers (ann.Flat.Query, bm25.Index.TopK) that
+	// iterate input in natural index order and want "smaller-index
+	// wins on tie" semantics.
+	//
+	// Setup: heap full with min at score 3 (item "a"). Pushing a new
+	// item at score 3 must NOT displace "a".
+	s := New[string](3)
+	s.Push("a", 3) // first arrival at score 3 — becomes the min
+	s.Push("b", 5)
+	s.Push("c", 7)
+	if s.Push("d", 3) {
+		t.Error("Push(d, 3) tying current min (a:3) returned true, want false")
+	}
+	result := s.Result()
+	gotItems := []string{result[0].Item, result[1].Item, result[2].Item}
+	wantItems := []string{"c", "b", "a"}
+	if !reflect.DeepEqual(gotItems, wantItems) {
+		t.Errorf("Result items = %v, want %v (older 'a' must stay on tie)", gotItems, wantItems)
+	}
+}
+
+func TestResult_DescendingOrder(t *testing.T) {
+	// Push a deliberately unsorted sequence; Result() must come back
+	// strictly descending by score.
+	s := New[int](7)
+	scores := []float64{3, 1, 4, 1, 5, 9, 2, 6, 5, 3, 5}
+	for i, sc := range scores {
+		s.Push(i, sc)
+	}
+	result := s.Result()
+	for i := 1; i < len(result); i++ {
+		if result[i-1].Score < result[i].Score {
+			t.Errorf("Result not descending at index %d: %v vs %v",
+				i, result[i-1].Score, result[i].Score)
+		}
+	}
+}
+
+func TestResult_TiesPreserved(t *testing.T) {
+	// Push three items, all score 5. K=3 so all are retained. Result()
+	// must contain all three; their internal order isn't constrained
+	// beyond all having score 5.
+	s := New[string](3)
+	s.Push("x", 5)
+	s.Push("y", 5)
+	s.Push("z", 5)
+	result := s.Result()
+	if len(result) != 3 {
+		t.Fatalf("Result() len = %d, want 3", len(result))
+	}
+	for i, r := range result {
+		if r.Score != 5 {
+			t.Errorf("Result[%d].Score = %v, want 5", i, r.Score)
+		}
+	}
+	seen := map[string]bool{}
+	for _, r := range result {
+		seen[r.Item] = true
+	}
+	for _, want := range []string{"x", "y", "z"} {
+		if !seen[want] {
+			t.Errorf("Result missing item %q", want)
+		}
+	}
+}
+
+func TestPush_LargeStream(t *testing.T) {
+	// 1000 items, K=10. Top 10 by score must come out in descending order
+	// and match the highest 10 input scores (995..986 here).
+	s := New[int](10)
+	for i := 0; i < 1000; i++ {
+		s.Push(i, float64(i%1000)+0.5)
+	}
+	result := s.Result()
+	if len(result) != 10 {
+		t.Fatalf("Result() len = %d, want 10", len(result))
+	}
+	// Scores must be exactly 999.5 down to 990.5.
+	for i, r := range result {
+		want := float64(999-i) + 0.5
+		if r.Score != want {
+			t.Errorf("Result[%d].Score = %v, want %v", i, r.Score, want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- First concrete Ship-tier perf fix from the [perf-investigation outcome](outputs/adr-025-perf-investigation-outcome.md) (ADR-025): replace `sort.Slice` over all candidates with a min-heap of size K in two sister code paths.
- New shared utility [`internal/topk`](internal/topk/topk.go) is a generic `Selector[T any]` — hand-rolled siftUp/siftDown to avoid `container/heap`'s `interface{}` boxing; strict `>` on at-capacity replace preserves the documented "smaller-index wins on tie" semantics for free (both callers iterate input in natural index order).
- Two-path implementation in each integrator keeps the documented `k<=0` / `k<0` escape hatches working; the heap path adds an O(K log K) stable secondary sort on the K-sized result to honor the ascending-Index/Doc tie-break the heap on its own can't guarantee.
- ADR-026 in [docs/DECISIONS.md](docs/DECISIONS.md) with full calibration evidence inline.

## Calibration evidence (Apple M1 Pro / Go 1.26.3 / darwin/arm64)

**benchstat (10 iter, all `p=0.000`):**

| target | sort-based | heap-based | Δ sec/op | Δ B/op |
|---|---|---|---|---|
| FlatQuery/N1k | 182.3µs | 103.2µs | **−43.4%** | 16,472 → 728 (**−95.6%**) |
| FlatQuery/N10k | 2.253ms | 990.2µs | **−56.1%** | 163,928 → 728 (**−99.6%**) |
| FlatQuery/N50k | 12.297ms | 4.926ms | **−59.9%** | 802,904 → 728 (**−99.9%**) |
| Score/N100 | 3.934µs | 1.099µs | **−72.1%** | 2,711 → 1,586 (−41.5%) |
| Score/N1000 | 8.782µs | 1.995µs | **−77.3%** | 15,961 → 5,961 (−62.7%) |

**End-to-end medium-corpus search latency** (`scripts/perf_collect.sh medium --modes=bm25,hybrid --chunkers=regex`, 378,524 chunks, 1000 queries):

| combo | metric | before | after | Δ |
|---|---|---|---|---|
| bm25-regex SEARCH | p50 | 11.5 ms | 1.88 ms | **−83.7%** |
| hybrid-regex SEARCH | p50 | 193 ms | 113.2 ms | **−41.4%** (upper end of ADR-025's 25-40% projection) |
| hybrid-regex SEARCH | p99 | 391 ms | 141 ms | −64.0% |

Index times **unchanged** (refactor only touches the search path).

**NDCG@10 safety check** (semble bench corpus, 63 repos / 1251 tasks, `--chunker regex` both sides):

| mode | before NDCG@10 | after NDCG@10 | Δ |
|---|---|---|---|
| bm25 | 0.6237 | 0.6237 | **0.0000 (exact)** |
| semantic | 0.6469 | 0.6469 | **0.0000 (exact)** |
| hybrid | 0.8418 | 0.8418 | **0.0000 (exact)** |

Top-K determinism verified: heap-based selection produces identical ranked output to sort-based selection.

## Test plan

- [x] `gofmt -l cmd internal` clean
- [x] `go vet ./...` clean
- [x] `go build ./...` ok
- [x] `go test ./...` green (full tree, incl. 9 new `internal/topk` tests + existing bm25/search/ann integration)
- [x] Benchstat ann (10 iter) — all 3 N values, `p=0.000`
- [x] Benchstat bm25 (10 iter) — both N values, `p=0.000`
- [x] End-to-end medium re-measurement vs perf-investigation HEAD baseline
- [x] NDCG@10 clean-BEFORE vs AFTER for all 3 modes — all exact match

## Notes

- **Two commits:** [`b61aaef`](https://github.com/townsendmerino/ken/commit/b61aaef) (`internal/topk` package) and [`fa5a43d`](https://github.com/townsendmerino/ken/commit/fa5a43d) (refactor + ADR-026). Reviewers can read the heap utility in isolation before the integrations.
- **ADR-025** (the investigation outcome that motivated this) currently lives in `outputs/adr-025-perf-investigation-outcome.md`, pending a separate promotion to `docs/DECISIONS.md`. ADR-026 references it as "pending promotion" and cross-links the path.
- **`Hit` / `Result` / public signatures unchanged** — existing callers (`search.hybridSearch`, the rerank pipeline) integrate unchanged.
- **No new third-party dependencies.** `internal/topk` is standard-library-only.
- **+3 allocs/op net** (4→7 for ann, 5→8 for bm25) is the Selector + result + scratch overhead; aggregate **bytes** allocated drops by orders of magnitude because the full N-sized candidate slice is gone.

Generated with [Claude Code](https://claude.com/claude-code)