### PR TITLE
docs: ADR-025 promotion + Phase 0 perf harness landing on main

### DIFF
--- a/cmd/ken/main.go
+++ b/cmd/ken/main.go
@@ -88,6 +88,7 @@ usage:
   ken index           <path>           [--watch|--no-watch] [--chunker regex|treesitter|line] [--mode bm25|semantic|hybrid] [--model DIR]
   ken search          <path> <query>...  [-k N] [--json] [--chunker ...] [--mode ...] [--model DIR]
   ken bench           <path>             [-k N] [--chunker ...] [--mode ...] [--model DIR]
+  ken perf            <subcmd> [args]    (index|search|watch — see 'ken perf' for full usage)
   ken build-index     <corpus>         -o <path> [--chunker ...] [--mode ...] [--model DIR]
   ken download-model                     [--model ORG/NAME] [--to DIR] [--force]
 
@@ -106,6 +107,11 @@ ken bench reads queries from stdin (one per line; lines starting with '#'
 ignored) and emits one JSON record per query to stdout against a single
 in-process index. Designed for the semble benchmark harness; see
 docs/BENCH.md.
+
+ken perf is the speed/memory measurement harness (sibling to ken bench;
+they share no state). Each invocation emits one JSON record on stdout
+plus optional pprof profiles. See docs/PERF.md and 'ken perf' for
+sub-command usage.
 
 ken download-model fetches the three files Model2Vec needs (model.safetensors,
 tokenizer.json, config.json) directly from HuggingFace into ~/.ken/model by
@@ -191,6 +197,8 @@ func main() {
 		os.Exit(cmdSearch(os.Args[2:]))
 	case "bench":
 		os.Exit(cmdBench(os.Args[2:]))
+	case "perf":
+		os.Exit(cmdPerf(os.Args[2:]))
 	case "build-index":
 		os.Exit(cmdBuildIndex(os.Args[2:]))
 	case "download-model":

--- a/cmd/ken/perf.go
+++ b/cmd/ken/perf.go
@@ -1,0 +1,571 @@
+// `ken perf` is the speed/memory measurement harness — sibling to
+// `ken bench` (NDCG/quality harness in main.go). The two share no state
+// by design: bench's wire format is consumed by scripts/bench_coir.py +
+// bench/semble/run_ken.py and must not regress, so perf concerns land
+// in their own subcommand instead of growing cmdBench.
+//
+// Each `ken perf {index,search,watch}` invocation emits exactly one
+// JSON record on stdout (consumed by scripts/perf_collect.sh +
+// benchstat + ad-hoc shell tooling). Optional pprof profiles land at
+// the path given by --cpuprofile / --memprofile.
+//
+// pprof helpers are inlined in this file rather than abstracted into
+// internal/perf — start/stop is two lines (pprof.StartCPUProfile(f) +
+// defer pprof.StopCPUProfile()), and wrapping that in a helper would
+// add an abstraction without payoff. Documented this judgment call
+// in the briefing back to the planning Claude.
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"runtime"
+	"runtime/debug"
+	"runtime/pprof"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/townsendmerino/ken/internal/perf"
+	"github.com/townsendmerino/ken/internal/search"
+)
+
+// perfMeta is the common set of "what produced this number" fields on
+// every `ken perf` record. Lets a future reader reproduce the run from
+// just the JSON output without consulting the surrounding shell context.
+type perfMeta struct {
+	Mode       string `json:"mode"`
+	Chunker    string `json:"chunker"`
+	ModelDir   string `json:"model_dir,omitempty"`
+	Commit     string `json:"commit,omitempty"`
+	GoVersion  string `json:"go_version"`
+	GOOS       string `json:"goos"`
+	GOARCH     string `json:"goarch"`
+	GOMAXPROCS int    `json:"gomaxprocs"`
+}
+
+func buildMeta(mode, chunker, modelDir string) perfMeta {
+	commit := ""
+	if info, ok := debug.ReadBuildInfo(); ok {
+		for _, s := range info.Settings {
+			if s.Key == "vcs.revision" {
+				commit = s.Value
+				break
+			}
+		}
+	}
+	return perfMeta{
+		Mode:       mode,
+		Chunker:    chunker,
+		ModelDir:   modelDir,
+		Commit:     commit,
+		GoVersion:  runtime.Version(),
+		GOOS:       runtime.GOOS,
+		GOARCH:     runtime.GOARCH,
+		GOMAXPROCS: runtime.GOMAXPROCS(0),
+	}
+}
+
+func cmdPerf(args []string) int {
+	if len(args) == 0 {
+		perfUsage()
+		return 2
+	}
+	switch args[0] {
+	case "index":
+		return cmdPerfIndex(args[1:])
+	case "search":
+		return cmdPerfSearch(args[1:])
+	case "watch":
+		return cmdPerfWatch(args[1:])
+	default:
+		perfUsage()
+		return 2
+	}
+}
+
+func perfUsage() {
+	fmt.Fprint(os.Stderr, `ken perf — speed/memory measurement harness
+
+usage:
+  ken perf index  <path>             [--mode ...] [--chunker ...] [--model DIR] [--cpuprofile FILE] [--memprofile FILE]
+  ken perf search <path>             [--queries FILE] [--n 1000] [-k 10] [--mode ...] [--chunker ...] [--model DIR] [--cpuprofile FILE] [--memprofile FILE]
+  ken perf watch  <path>             [--edits 10] [--mode ...] [--chunker ...] [--model DIR]
+
+Emits exactly one JSON record on stdout per invocation; pprof profiles
+land at the --cpuprofile / --memprofile paths. Sibling to 'ken bench'
+(NDCG/quality harness) — the two share no state. See docs/PERF.md.
+`)
+}
+
+// perfIndexRecord is the JSON shape `ken perf index` writes to stdout.
+type perfIndexRecord struct {
+	IndexMs      float64         `json:"index_ms"`
+	Chunks       int             `json:"chunks"`
+	BytesIndexed int             `json:"bytes_indexed"`
+	AllocDelta   perf.AllocDelta `json:"alloc_delta"`
+	Heap         perf.HeapStats  `json:"heap"`
+	perfMeta                     // embedded; flattened into the JSON record
+}
+
+func cmdPerfIndex(args []string) int {
+	rest, chunker, modeStr, model, err := commonFlags(args)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "ken: "+err.Error())
+		perfUsage()
+		return 2
+	}
+	rest, cpuProfile, err := extractFlag(rest, "cpuprofile", "")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "ken: "+err.Error())
+		return 2
+	}
+	rest, memProfile, err := extractFlag(rest, "memprofile", "")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "ken: "+err.Error())
+		return 2
+	}
+	if len(rest) != 1 {
+		perfUsage()
+		return 2
+	}
+	mode, err := search.ParseMode(modeStr)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "ken: "+err.Error())
+		return 2
+	}
+
+	// CPU profile wraps just the index build — the work we want to attribute.
+	if cpuProfile != "" {
+		f, err := os.Create(cpuProfile)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "ken: --cpuprofile: "+err.Error())
+			return 1
+		}
+		defer f.Close()
+		if err := pprof.StartCPUProfile(f); err != nil {
+			fmt.Fprintln(os.Stderr, "ken: pprof.StartCPUProfile: "+err.Error())
+			return 1
+		}
+		defer pprof.StopCPUProfile()
+	}
+
+	// Force a GC so the alloc baseline is from a stable starting point —
+	// otherwise the delta picks up whatever was accumulating during
+	// process startup (flag parsing, debug.ReadBuildInfo, etc.).
+	runtime.GC()
+	allocStart := perf.StartAlloc()
+	started := time.Now()
+	ix, err := search.FromFS(os.DirFS(rest[0]), mode, chunker, model)
+	indexMs := float64(time.Since(started).Microseconds()) / 1000.0
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "ken: "+err.Error())
+		return 1
+	}
+	allocDelta := allocStart.Delta()
+	heap := perf.HeapSnapshot()
+
+	if memProfile != "" {
+		f, err := os.Create(memProfile)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "ken: --memprofile: "+err.Error())
+			return 1
+		}
+		defer f.Close()
+		runtime.GC() // pprof convention: GC before heap profile so it reflects live objects, not garbage.
+		if err := pprof.WriteHeapProfile(f); err != nil {
+			fmt.Fprintln(os.Stderr, "ken: pprof.WriteHeapProfile: "+err.Error())
+			return 1
+		}
+	}
+
+	bytesIndexed := 0
+	for _, c := range ix.Chunks() {
+		if c.Tombstoned {
+			continue
+		}
+		bytesIndexed += len(c.Text)
+	}
+
+	rec := perfIndexRecord{
+		IndexMs:      indexMs,
+		Chunks:       ix.Len(),
+		BytesIndexed: bytesIndexed,
+		AllocDelta:   allocDelta,
+		Heap:         heap,
+		perfMeta:     buildMeta(modeStr, chunker, model),
+	}
+	if err := json.NewEncoder(os.Stdout).Encode(rec); err != nil {
+		fmt.Fprintln(os.Stderr, "ken: "+err.Error())
+		return 1
+	}
+	return 0
+}
+
+// perfSearchRecord is the JSON shape `ken perf search` writes to stdout.
+//
+// Latency is measured per ix.Search call (not per result); alloc_per_query
+// is the total alloc delta across all N searches divided by N, not measured
+// per call (per-call MemStats reads would themselves add measurable noise).
+type perfSearchRecord struct {
+	IndexMs       float64           `json:"index_ms"`
+	NQueries      int               `json:"n_queries"`
+	K             int               `json:"k"`
+	Latency       perf.LatencyStats `json:"latency"`
+	AllocPerQuery perf.AllocDelta   `json:"alloc_per_query"`
+	perfMeta
+}
+
+func cmdPerfSearch(args []string) int {
+	rest, chunker, modeStr, model, err := commonFlags(args)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "ken: "+err.Error())
+		perfUsage()
+		return 2
+	}
+	rest, queriesFile, err := extractFlag(rest, "queries", "")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "ken: "+err.Error())
+		return 2
+	}
+	rest, nStr, err := extractFlag(rest, "n", "1000")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "ken: "+err.Error())
+		return 2
+	}
+	rest, kStr, err := extractFlag(rest, "k", "10")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "ken: "+err.Error())
+		return 2
+	}
+	rest, cpuProfile, err := extractFlag(rest, "cpuprofile", "")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "ken: "+err.Error())
+		return 2
+	}
+	rest, memProfile, err := extractFlag(rest, "memprofile", "")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "ken: "+err.Error())
+		return 2
+	}
+	if len(rest) != 1 {
+		perfUsage()
+		return 2
+	}
+	if queriesFile == "" {
+		fmt.Fprintln(os.Stderr, "ken: perf search requires --queries FILE")
+		return 2
+	}
+	nTarget, err := strconv.Atoi(nStr)
+	if err != nil || nTarget <= 0 {
+		fmt.Fprintln(os.Stderr, "ken: --n expects a positive integer")
+		return 2
+	}
+	k, err := strconv.Atoi(kStr)
+	if err != nil || k < 0 {
+		fmt.Fprintln(os.Stderr, "ken: -k expects a non-negative integer")
+		return 2
+	}
+	mode, err := search.ParseMode(modeStr)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "ken: "+err.Error())
+		return 2
+	}
+
+	// Load queries. Same format as `ken bench` stdin: newline-separated;
+	// '#' comments and blank lines skipped.
+	queries, err := loadQueryFile(queriesFile)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "ken: "+err.Error())
+		return 1
+	}
+	if len(queries) == 0 {
+		fmt.Fprintln(os.Stderr, "ken: --queries file has no non-comment lines")
+		return 1
+	}
+
+	// Build the index once; all latency samples come from ix.Search on
+	// the warm index.
+	indexStart := time.Now()
+	ix, err := search.FromFS(os.DirFS(rest[0]), mode, chunker, model)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "ken: "+err.Error())
+		return 1
+	}
+	indexMs := float64(time.Since(indexStart).Microseconds()) / 1000.0
+
+	// CPU profile wraps just the search loop (not the index build).
+	if cpuProfile != "" {
+		f, err := os.Create(cpuProfile)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "ken: --cpuprofile: "+err.Error())
+			return 1
+		}
+		defer f.Close()
+		if err := pprof.StartCPUProfile(f); err != nil {
+			fmt.Fprintln(os.Stderr, "ken: pprof.StartCPUProfile: "+err.Error())
+			return 1
+		}
+		defer pprof.StopCPUProfile()
+	}
+
+	// Cycle through queries until we've collected nTarget samples. If the
+	// file already has >= nTarget queries we still iterate exactly nTarget
+	// — using all of them while pretending the sample size is N would
+	// confuse benchstat.
+	samples := make([]time.Duration, nTarget)
+	runtime.GC()
+	allocStart := perf.StartAlloc()
+	for i := 0; i < nTarget; i++ {
+		q := queries[i%len(queries)]
+		started := time.Now()
+		_ = ix.Search(q, k)
+		samples[i] = time.Since(started)
+	}
+	allocDelta := allocStart.Delta()
+
+	if memProfile != "" {
+		f, err := os.Create(memProfile)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "ken: --memprofile: "+err.Error())
+			return 1
+		}
+		defer f.Close()
+		runtime.GC()
+		if err := pprof.WriteHeapProfile(f); err != nil {
+			fmt.Fprintln(os.Stderr, "ken: pprof.WriteHeapProfile: "+err.Error())
+			return 1
+		}
+	}
+
+	rec := perfSearchRecord{
+		IndexMs:  indexMs,
+		NQueries: nTarget,
+		K:        k,
+		Latency:  perf.LatencyOf(samples),
+		AllocPerQuery: perf.AllocDelta{
+			BytesAllocated:   allocDelta.BytesAllocated / uint64(nTarget),
+			ObjectsAllocated: allocDelta.ObjectsAllocated / uint64(nTarget),
+		},
+		perfMeta: buildMeta(modeStr, chunker, model),
+	}
+	if err := json.NewEncoder(os.Stdout).Encode(rec); err != nil {
+		fmt.Fprintln(os.Stderr, "ken: "+err.Error())
+		return 1
+	}
+	return 0
+}
+
+// loadQueryFile reads a newline-separated query file in the same format
+// `ken bench` consumes from stdin: '#' comments and blank lines skipped.
+func loadQueryFile(path string) ([]string, error) {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w", path, err)
+	}
+	var out []string
+	for _, line := range strings.Split(string(b), "\n") {
+		q := strings.TrimSpace(line)
+		if q == "" || strings.HasPrefix(q, "#") {
+			continue
+		}
+		out = append(out, q)
+	}
+	return out, nil
+}
+
+// perfWatchRecord is the JSON shape `ken perf watch` writes to stdout.
+//
+// Latency is end-to-end edit → snapshot publish, so the v0.3 debouncer
+// (default 2s; ADR-012) dominates and that's the right thing to measure:
+// users see this latency, not the goroutine-internal post-debounce build
+// time. Bracket that against InitialIndexMs to factor out the debouncer.
+type perfWatchRecord struct {
+	InitialIndexMs float64           `json:"initial_index_ms"`
+	NEdits         int               `json:"n_edits"`
+	Latency        perf.LatencyStats `json:"latency"`
+	perfMeta
+}
+
+func cmdPerfWatch(args []string) int {
+	rest, chunker, modeStr, model, err := commonFlags(args)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "ken: "+err.Error())
+		perfUsage()
+		return 2
+	}
+	rest, editsStr, err := extractFlag(rest, "edits", "10")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "ken: "+err.Error())
+		return 2
+	}
+	if len(rest) != 1 {
+		perfUsage()
+		return 2
+	}
+	edits, err := strconv.Atoi(editsStr)
+	if err != nil || edits <= 0 {
+		fmt.Fprintln(os.Stderr, "ken: --edits expects a positive integer")
+		return 2
+	}
+	mode, err := search.ParseMode(modeStr)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "ken: "+err.Error())
+		return 2
+	}
+
+	// Work on a temp copy so we don't mutate the user's corpus. fsnotify
+	// is per-directory tree, so the temp dir is the right scope.
+	tmp, err := os.MkdirTemp("", "ken-perf-watch-*")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "ken: "+err.Error())
+		return 1
+	}
+	defer os.RemoveAll(tmp)
+
+	if err := copyTree(rest[0], tmp); err != nil {
+		fmt.Fprintln(os.Stderr, "ken: copy corpus to temp: "+err.Error())
+		return 1
+	}
+
+	// Pick a target file to mutate: first regular file in the copy
+	// that's > 0 bytes and isn't under .git/ (the watcher prunes .git
+	// anyway, so edits there would never trigger a flush).
+	target, err := pickWatchTarget(tmp)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "ken: "+err.Error())
+		return 1
+	}
+
+	initStart := time.Now()
+	wix, err := search.NewWatchedIndex(tmp, mode, chunker, model, true)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "ken: "+err.Error())
+		return 1
+	}
+	initialIndexMs := float64(time.Since(initStart).Microseconds()) / 1000.0
+	defer wix.Close()
+
+	// Single-slot flush channel so we never block the debouncer goroutine.
+	// Drained at the top of each edit iteration so each measurement is
+	// fresh (an in-flight flush from before the loop body started would
+	// otherwise be charged to iteration i).
+	flushCh := make(chan struct{}, 1)
+	wix.SetOnFlush(func(string) {
+		select {
+		case flushCh <- struct{}{}:
+		default:
+		}
+	})
+
+	samples := make([]time.Duration, 0, edits)
+	const editTimeout = 30 * time.Second // generous; debounce is 2s, full reindex of a small corpus is sub-second
+	for i := 0; i < edits; i++ {
+		// Drain any leftover flush signal from before this iteration.
+		select {
+		case <-flushCh:
+		default:
+		}
+		started := time.Now()
+		marker := fmt.Sprintf("\n// ken-perf-watch edit %d at %s\n", i, started.Format(time.RFC3339Nano))
+		if err := appendToFile(target, marker); err != nil {
+			fmt.Fprintln(os.Stderr, "ken: append to target: "+err.Error())
+			return 1
+		}
+		select {
+		case <-flushCh:
+			samples = append(samples, time.Since(started))
+		case <-time.After(editTimeout):
+			fmt.Fprintf(os.Stderr, "ken: timed out (%v) waiting for flush after edit %d\n", editTimeout, i)
+			return 1
+		}
+	}
+
+	rec := perfWatchRecord{
+		InitialIndexMs: initialIndexMs,
+		NEdits:         edits,
+		Latency:        perf.LatencyOf(samples),
+		perfMeta:       buildMeta(modeStr, chunker, model),
+	}
+	if err := json.NewEncoder(os.Stdout).Encode(rec); err != nil {
+		fmt.Fprintln(os.Stderr, "ken: "+err.Error())
+		return 1
+	}
+	return 0
+}
+
+// copyTree mirrors src into dst (dst must already exist). Preserves
+// directory structure but not permissions/timestamps — we just need
+// readable files for the watcher to see.
+func copyTree(src, dst string) error {
+	return filepath.WalkDir(src, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, relErr := filepath.Rel(src, path)
+		if relErr != nil {
+			return relErr
+		}
+		if rel == "." {
+			return nil
+		}
+		target := filepath.Join(dst, rel)
+		if d.IsDir() {
+			return os.MkdirAll(target, 0o755)
+		}
+		b, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return readErr
+		}
+		return os.WriteFile(target, b, 0o644)
+	})
+}
+
+// pickWatchTarget returns the path of the first non-empty regular file
+// under root that isn't inside a .git/ directory (which the watcher
+// ignores anyway). The choice is arbitrary — we just need any file
+// whose edit will trigger a re-index.
+func pickWatchTarget(root string) (string, error) {
+	var found string
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if d.IsDir() {
+			if d.Name() == ".git" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		info, infoErr := d.Info()
+		if infoErr != nil || info.Size() == 0 {
+			return nil
+		}
+		found = path
+		return filepath.SkipAll
+	})
+	if err != nil {
+		return "", err
+	}
+	if found == "" {
+		return "", fmt.Errorf("no non-empty regular files under %s to mutate", root)
+	}
+	return found, nil
+}
+
+// appendToFile opens path for append, writes data, closes. fsnotify
+// observes the write and the debouncer schedules a flush.
+func appendToFile(path, data string) error {
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o644)
+	if err != nil {
+		return err
+	}
+	if _, err := f.WriteString(data); err != nil {
+		_ = f.Close()
+		return err
+	}
+	return f.Close()
+}

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -30,6 +30,7 @@ ADR statuses: **Proposed** (documenting design alternatives; no implementation d
 | [ADR-022](#adr-022-rename-column--rename-constraint-folding-via-eager-application-v081-part-c) | RENAME COLUMN + RENAME CONSTRAINT folding via eager application (v0.8.1 Part C) | Accepted |
 | [ADR-023](#adr-023-gotreesitter-grammar_subset-machinery--binary-size-reduction-outcome-v082-investigation-outcome) | `gotreesitter` `grammar_subset` machinery + binary-size reduction outcome (v0.8.2 investigation outcome) | Accepted |
 | [ADR-024](#adr-024-pre-built-embedded-indices-for-mcprun-v083) | Pre-built embedded indices for `mcp.Run` (v0.8.3) | Accepted |
+| [ADR-025](#adr-025-perf-campaign-phase-1-investigation-outcome--hotspot-identification-across-small--medium-workloads) | Perf-campaign Phase 1 investigation outcome — hotspot identification across small + medium workloads | Accepted |
 | [ADR-026](#adr-026-paired-heap-refactor-for-annflatquery--bm25indextopk-v084) | Paired heap refactor for `ann.Flat.Query` + `bm25.Index.TopK` via shared `internal/topk` (v0.8.4) | Accepted |
 
 ---
@@ -1314,6 +1315,145 @@ Serialize the built `*search.Index` artifact (chunks slice + parallel embedding 
 - **No new third-party dependencies.** Custom binary serialization uses `encoding/binary`, `hash/crc32`, and the existing `io/fs` plumbing. The dep tree stays clean.
 
 - **v0.8.3 ready to tag after this lands.** Four-commit cadence on `v0.8.3-prebuilt-indices`: (1) serialize/deserialize primitives + walker prune, (2) `ken build-index` CLI subcommand, (3) `mcp.Run` auto-discovery + `Options.PrebuiltIndex`, (4) docs (this ADR + CHANGELOG + README + DESIGN.md). Closes [#10](https://github.com/townsendmerino/ken/issues/10).
+
+---
+
+## ADR-025: Perf-campaign Phase 1 investigation outcome — hotspot identification across small + medium workloads
+
+**Status:** Accepted
+
+**Date:** 2026-05-26
+
+**Extends:** [ADR-010](#adr-010-tree-sitter-via-gotreesitter-instead-of-wazerowasm) (gotreesitter selection), [ADR-011](#adr-011-default-chunker-stays-regex-in-v020-treesitter-is-opt-in) (regex stays default), [ADR-016](#adr-016-embedded-corpus-mcp-build-pattern-via-mcprun-library-function) (mcp.Run pattern), [ADR-023](#adr-023-gotreesitter-grammar_subset-machinery--binary-size-reduction-outcome-v082-investigation-outcome) (gotreesitter selectivity investigation), [ADR-024](#adr-024-pre-built-embedded-indices-for-mcprun-v083) (pre-built indices).
+
+**Related:** `outputs/treesitter-port-considerations.md` (future-ADR seed; the arena finding here motivates that seed's Tier 2 ranking).
+
+## Context
+
+The v0.8.x release cadence settled the calibration story; v0.9 (or rolling point releases — release shape is task #11, decided after this ADR) is the perf-campaign cycle. [Phase 0](PERF.md) built the measurement infrastructure (`ken perf` subcommand + per-package benchmarks + `scripts/perf_collect.sh` + `docs/PERF.md` methodology). Phase 1 ran the harness against the small (ken itself, ~150 Go files) and medium (semble bench corpus, ~378k chunks, ~715 MB of source) workloads on native arm64 darwin / Go 1.26.3 / M1 Pro.
+
+Phase 1 was an **investigation pass**, not a publication pass. Discipline carries over from `docs/BENCH.md` and ADR-023:
+
+- The "Headline numbers" section in `docs/PERF.md` remains empty until N≥10 median + second-machine confirmation per the documented acceptance threshold.
+- The "Empirical findings" section, by contrast, holds investigation-pass observations with explicit single-run / single-machine caveats — same shape as the per-version findings in `docs/BENCH.md`.
+- Predictions were written down in `outputs/perf-investigation-plan.md` **before** the harness was built. Phase 1 grades them rather than retrofitting.
+
+Workloads measured:
+
+- **Small** (`ken@97feb5e`): 1,560 chunks across 9 mode × chunker combos. ~26 s wall total. Cross-product complete.
+- **Medium** (`~/.cache/semble-bench`, ~19 repos aggregate per upstream `repos.json`): 378k–380k chunks. 4 combos run (bm25/hybrid × regex/treesitter). 2h 49m wall total (treesitter combos dominated). Cross-product *not* complete; targeted via `scripts/perf_collect.sh --modes --chunkers` filter.
+- **Large + giant — explicitly skipped this pass.** Reasoning under "Alternatives considered" below.
+
+One incidental finding the harness exposed before any measurement could complete: a panic in `internal/chunk/treesitter/Chunker.Chunk` when gotreesitter produces a parse-error-recovery node with `EndByte() < StartByte()`. Fixed in commit `120fc06` before Phase 1 medium proceeded. **The perf campaign surfaced a latent correctness bug** — a documented Phase-0 expectation that materialized.
+
+## Phase 1 findings — predictions vs evidence
+
+The seven predictions from `outputs/perf-investigation-plan.md`, graded:
+
+| # | Prediction | Status | Evidence |
+| --- | --- | --- | --- |
+| 1 | Embed inference dominates indexing CPU | ✓ confirmed at small (46% of hybrid-treesitter index CPU) | Medium-scale CPU profile needed to compute exact share at 378k chunks; the wall-time signature (semantic mode adds ~140s on top of bm25 mode at medium-regex) is consistent. |
+| 2 | BM25 tokenizer allocates heavily | ✓ **strongly** confirmed; 45% of bm25-regex indexing allocs at medium (8.7 GB out of 19.3 GB) | Tokenizer split: `Tokenize.func1` 5.7 GB + `camelSplit` 2.6 GB + `Tokenize-range1` 0.4 GB. Per-chunk alloc grew from 35 KB (small) → 53 KB (medium). |
+| 3 | ANN flat dominates search at scale | ✓ **strongly** confirmed | Hybrid p50 = 11.5 ms at small (1,560 chunks) → 193 ms at medium (378,524 chunks). bm25 p50 stayed at ~12 ms; the entire delta is the semantic + ANN-flat work. **Medium hybrid-regex pprof: `ann.Flat.Query` is 78.56% of search CPU (cum) at medium scale.** Inside that: ~68% is vector cosine (`Flat.Query.func1`), ~32% is `sort.Slice` over the candidate-score list. |
+| 4 | File walk is NOT hot | ✓ confirmed (essentially invisible in CPU profiles at both scales) | At medium bm25-regex: walk is dwarfed by tokenizer + GC. |
+| 5 | Watch swap is NOT hot | not measured (no medium-scale watch profile) | `ken perf watch` exists; the medium-scale watch-mode latency is an open question Phase 1 didn't answer. |
+| 6 | ParserPool is NOT hot | ✓ confirmed | No pool overhead visible in either small or medium treesitter profiles. The ADR-010 pool-reuse pattern is doing its job. |
+| 7 | Rerank is NOT hot at k=20 | ✗ falsified at small; ✓ **re-confirmed at medium** | 28% of hybrid-regex search CPU at small goes through `rerankTopK` (24% `regexp.tryBacktrack` inside `filePathPenalty`). **At medium, `filePathPenalty` does not appear in the top 30 cumulative frames** (cutoff ~0.5%). At scale, ANN flat (78.56%) so dominates search that the rerank+penalty work is invisible in the noise. The prediction "rerank not hot" holds at production scale even though it failed at toy scale. |
+| (new) | GC dominates CPU at scale | ✓ **new finding** | At medium bm25-regex: `runtime.gcBgMarkWorker` + `tryDeferToSpanScan` + `scanObject` consume ~50% of indexing CPU and ~36% of search CPU. Direct consequence of the allocation pattern, but only visible at scale where the heap stabilizes at 7–8 GB. |
+| (new) | Treesitter scales super-linearly | ✓ **new finding** | Per-chunk arena allocation: 450 KB at small → 2.9 MB at medium (6.4× growth per chunk). 1.09 TB cumulative allocation to index 379k chunks via bm25-treesitter. 37-minute wall time. The gotreesitter arena pattern (per `outputs/treesitter-port-considerations.md`) compounds badly with file complexity in the semble corpus. |
+| (new) | `bm25.Index.TopK` uses `sort.Slice` instead of a heap | ✓ **new actionable finding** | At medium bm25-regex search: `sort.Slice` + `sort.pdqsort_func` = 36% of search CPU. At 378k chunks with K=10, the O(N log N) sort over all candidates is the dominant in-tree search cost. Classic top-K heap (O(N log K)) is the canonical fix. |
+
+**Two predictions were strongly confirmed, two were falsified or refined, three new findings emerged.** This is the calibration discipline working as intended — writing predictions before measurement makes the surprises visible.
+
+## Hotspot ranking — ordered by ROI × confidence × in-tree-actionability
+
+| # | Hotspot | Location | Confidence | Expected impact | Status |
+| --- | --- | --- | --- | --- | --- |
+| 1 | **ANN flat scan dominates hybrid search** | `internal/ann/` | **Strongly confirmed at medium (78.56% of hybrid-regex search CPU)** | Search latency −80%+ at giant scale with HNSW; ~30% achievable inside flat via candidate-selection refactor (see #1a) | Two-track. Real algorithmic fix (HNSW) requires dep choice or in-tree impl; in-tree quick-win (#1a) is the candidate-selection refactor inside the existing flat scan. |
+| 1a | `ann.Flat.Query` uses `sort.Slice` over ALL candidates for top-K | `internal/ann/` | High (medium-scale CPU profile — 30.88% of hybrid search CPU is `sort.Slice` inside `Flat.Query`) | Hybrid search CPU −20–30% at medium scale without changing the algorithm; complementary to eventual HNSW | **Worth shipping immediately.** Same min-heap-of-size-K refactor as #2; in fact the two changes share a code template. |
+| 2 | `bm25.Index.TopK` uses `sort.Slice` over all candidates | `internal/bm25/` | High (medium-scale CPU profile — 36% of bm25 search CPU is `sort.Slice`) | Search CPU −25–40% on bm25 path at corpus sizes ≥ ~100k chunks | Worth shipping. Same min-heap pattern as #1a; sister refactor. |
+| 3 | BM25 tokenizer string allocations | `internal/bm25/Tokenize` + `camelSplit` | High (medium-scale alloc profile — 45% of bm25-regex indexing allocs) | Indexing allocs −45%, GC time −proportional, indexing wall time −20–30% | Worth shipping. Use `[]byte` slices into source rather than allocating new strings; pool scratch buffers. |
+| 4 | Embed `weightedMeanPoolSafe` accumulator | `internal/embed/` | High at small (23% of hybrid-treesitter CPU); medium-scale share not separately computed but the embed pass scales linearly with chunk count | Indexing CPU −10–20% with SIMD; pure-Go-no-cgo constraint shapes the implementation | Worth investigating. `golang.org/x/sys/cpu` + per-GOARCH assembly stubs is the established pattern (`crypto/sha256` etc. do this). Defer until #1a–#3 land — the relative share will shift. |
+| 5 | gotreesitter node arena | upstream | High (468 MB / 53.6% of allocations at small; 1.09 TB cumulative at medium) | Bounded by gotreesitter upstream + ADR-023's selectivity work | Future-ADR seed exists (`outputs/treesitter-port-considerations.md`). Tier 0–3 mitigation hierarchy documented. Don't port; consider targeted upstream PR after the open selective-grammar issue resolves. |
+| 6 | HNSW (replacement for ANN flat) | `internal/ann/` | Documented in `docs/DESIGN.md` §10 | Search latency −80%+ at giant scale | Documented future work. Real dependency (pure-Go HNSW choice) or in-tree impl. Trigger to elevate: real-user latency complaint, OR a pure-Go HNSW dep emerges that meets the no-cgo bar with good maintenance signal. |
+| (demoted) | `filePathPenalty` regex backtracking | `internal/search/penalties.go` | High at small (24% of hybrid search CPU); **falsified at medium** (does not appear in top-30 frames; <0.5% cumulative) | Search CPU −up to 24% at small scale only; negligible at production scale | **Demoted from Ship-tier.** At small scale the regex matters; at scale it's lost in ANN-flat noise. Only worth fixing if a real user reports search-latency pain on a small-corpus deployment (e.g., a few-thousand-chunk SDK docs server). |
+
+## Decision
+
+**Three categories of follow-on:**
+
+### A. Ship (subject to NDCG calibration discipline)
+
+- **#1a `ann.Flat.Query` → min-heap of size K** (NEW Ship-tier — highest priority after medium pprof). 30.88% of hybrid search CPU at medium goes to `sort.Slice` inside `Flat.Query` sorting all 378k candidate scores to take K=10. Min-heap-of-size-K is the canonical fix. **NDCG regression risk:** none expected — top-K by cosine score is deterministic regardless of full-sort vs heap-based selection, so the same K results emerge in the same order. NDCG@10 re-run is the safety check but expected to be a no-op.
+- **#2 `bm25.Index.TopK` → min-heap of size K.** Sister refactor to #1a — same pattern, same code template, same NDCG-risk profile (none expected). 36% of bm25 search CPU at medium. Often shipped together with #1a as a single PR since the two share a heap utility.
+- **#3 BM25 tokenizer alloc reduction.** Pool allocations; use `[]byte` slices into source for camelCase/PascalCase splits rather than allocating fresh strings; share scratch buffers across calls. **NDCG regression risk:** real — different tokenization changes IDF, which changes BM25 ranking. The discipline is: run the semble NDCG benchmark before and after, accept ≤ ±0.005 shift per `docs/BENCH.md`, write a calibration-discipline ADR if the shift is bigger and the perf win is large enough to justify.
+
+**`filePathPenalty` is NOT in the Ship tier** despite being a clear hotspot at small scale, because the medium pprof showed it disappears into ANN-flat noise (<0.5% of cumulative search CPU at 378k chunks). Documented as demoted in the hotspot table; revisit only on a real small-corpus user report.
+
+These three are independent and ship as **rolling point releases** (decided alongside this ADR; no v0.9.0 themed campaign):
+
+- **v0.8.4** — #1a + #2 paired heap refactor. Lower risk (no NDCG impact expected), immediate user-impact win, natural to ship together since they share a heap-of-size-K code template.
+- **v0.8.5** — #3 BM25 tokenizer alloc reduction. Carries real NDCG-regression risk; ships with its own calibration-discipline ADR if the shift exceeds ±0.005 per `docs/BENCH.md`.
+
+The rolling shape was chosen over a v0.9.0 themed campaign because each fix is independently valuable and there's no narrative coherence benefit to gating them on a single release. Future fixes (#4 embed SIMD, #6 HNSW) can also ship rolling when their triggers fire.
+
+### B. Defer with named triggers
+
+- **#4 HNSW for ANN flat replacement.** Gated on choosing a pure-Go HNSW dependency or accepting an in-tree implementation. Documented in `docs/DESIGN.md` §10. Trigger to revisit: a real user reports search latency as actionable pain on a 100k+ chunk corpus (already on the threshold for some users), OR a pure-Go HNSW dep emerges that meets the no-cgo bar with good maintenance signal.
+- **#5 Embed SIMD accumulator.** Gated on #1–#3 landing first (the relative share will shift) and on a pure-Go-no-cgo-compatible SIMD pattern matching the `crypto/sha256` precedent for per-GOARCH assembly. Trigger to revisit: post-Phase-1-fixes re-measurement still shows embed accumulator > 20% of indexing CPU.
+- **#6 gotreesitter arena scaling.** Per `outputs/treesitter-port-considerations.md` Tier 2: targeted upstream PR after the open selective-grammar issue resolves. Triggers documented in that seed.
+
+### C. Architectural ceilings — document, don't try to "fix"
+
+- **GC dominates CPU at scale.** This is the *consequence* of the allocation pattern, not a separate hotspot. Reducing allocations (#2 above) reduces GC pressure proportionally; that's the actionable lever. Documented in `docs/PERF.md` "Empirical findings" so users running ken-mcp on corpora ≥ ~100k chunks know that the steady-state heap is 5–10 GB and to size their deployment hardware accordingly.
+- **Heap inuse at medium = 7 GB.** Not a bug, a property — the BM25 postings list + chunk source storage + (for hybrid) embed matrix all scale linearly with chunk count. Document the per-chunk memory cost in `docs/PERF.md` so SDK authors using `mcp.Run` can estimate their binary's runtime memory ahead of release.
+
+### D. Calibration discipline carries forward
+
+- **`docs/PERF.md` "Headline numbers" stays empty** until N≥10 median + second-machine confirmation per the documented acceptance threshold. Phase 1 was investigation, not publication.
+- **`docs/PERF.md` "Empirical findings" updates** to summarize the corroborated predictions, the falsified ones, and the new findings — with cross-reference to this ADR. Includes the single-run / single-machine caveats and the Rosetta vs native arm64 footnote.
+- **Reconcile `docs/PERF.md` workload table.** The "~19 repos aggregate" entry for the medium workload is inconsistent with `docs/BENCH.md`'s 63-repo CoIR mention; the actual indexed chunk count (~378k) is closer to the full corpus than to a 19-repo subset. Cleanup ships in the same docs commit as the "Empirical findings" update.
+
+## Alternatives considered
+
+- **Run large + giant workloads before this ADR.** Rejected. Per the analysis at the end of Phase 1: small + medium gave decisive evidence of the scaling pattern; large would mostly confirm linear-or-worse extrapolation already visible. Per-chunk treesitter alloc at large scale projects to ~10–20 MB/chunk extrapolating the small→medium 6.4× growth ratio; verifying that exactly would cost ~12+ hours of wall time for marginal new information. Re-runnable at any time via the harness (the targeted `--modes`/`--chunkers` filter makes it tractable when justified). Trigger to revisit: an SDK author or operator reports actionable pain at large scale, or a perf-regression check needs a baseline.
+- **Run the full mode × chunker cross-product at medium.** Rejected during Phase 1 itself (the original `scripts/perf_collect.sh medium` was killed at ~1:28 elapsed when extrapolation showed 4–8 hours wall time). vscode-claude added `--modes` / `--chunkers` filters; the targeted 4-combo run took 2h 49m. Full cross-product wasn't necessary because semantic mode's wall time at small was indistinguishable from hybrid mode (the BM25 indexing is "free" within semantic build path), and line chunker at scale answers no question regex doesn't already answer.
+- **Publish "Headline numbers" from Phase 1's single-machine, single-run data.** Rejected. `docs/PERF.md`'s acceptance threshold is explicit: median-of-N + second-machine confirm before publication. Phase 1's job was investigation, not headlining. Promoting any of these numbers without the calibration steps would erode the discipline this campaign exists to demonstrate.
+- **Commit to a v0.9.0 themed release shape inside this ADR.** Rejected by scope. Release-shape decision (task #11) is the *next* decision after this one; it depends on whether the three Ship-tier fixes (above) land as separate Parts (matching v0.8.x cadence) or as a single release. Forcing the decision into this ADR confuses what's empirical (the findings) with what's a release-engineering choice.
+- **Ship "treesitter is alloc-pathological at scale" as a calibration warning in the README.** Considered, deferred. The story is more nuanced than a single bullet: regex is the documented default, treesitter is opt-in, `mcp.Run` users via ADR-024 pay the cost once at `ken build-index` time. The right place for this nuance is the `docs/PERF.md` "Empirical findings" section, not the README. Revisit if treesitter usage patterns shift.
+
+## Consequences
+
+- **Three perf wins enter the in-tree development queue** (#1a `ann.Flat.Query` heap, #2 `bm25.Index.TopK` heap, #3 BM25 tokenizer alloc reduction). #1a and #2 are natural pair partners (same heap-of-size-K template) and may ship as one PR; #3 is independent and has a real NDCG-regression-risk check. Each ships with its own ADR when it lands (ADR-026, ADR-027 in some ordering), with the calibration discipline (benchstat sign-off, second machine confirm, NDCG@10 within ±0.005) applied per fix.
+- **Future-ADR seed `outputs/treesitter-port-considerations.md` gains a concrete empirical anchor.** The Tier 2 upstream-PR conversation now has medium-scale numbers (1.09 TB cumulative arena alloc, 37-minute index wall time) to point at if/when the conversation is opened upstream.
+- **`docs/PERF.md` "Empirical findings" lands with the Phase 1 summary** in the same docs commit as this ADR. Workload-table cleanup (19 vs 63 repos) lands alongside.
+- **The harness is proven by use.** `ken perf` + `scripts/perf_collect.sh` + `internal/perf/` survived a real investigation pass including a correctness-bug-discovery, a multi-hour stress run, and the chunker-fix loop. Phase 0's "harness before headlines" discipline paid for itself.
+- **Large + giant workloads are deferred but reachable.** The harness exists; the filter flag makes targeted runs cheap; the only thing missing is the trigger to re-run. Documented so a future contributor knows the cost (~12+ hours for a treesitter combo at large scale) and the value (confirmatory rather than informative).
+- **The calibration credibility holds.** v0.8.2 / ADR-023 established the "investigation outcome with named triggers" shape. This ADR extends it: investigation that surfaces concrete fixes (rather than ADR-023's "the answer is no"). Both shapes are legitimate; both keep the "headline numbers don't ship until they survive a re-run" discipline visible.
+
+## Triggers to ADR-026+ (or to follow-on investigation passes)
+
+- **Trigger A — Ship-tier fix lands:** when #1, #2, or #3 lands as a PR, the accompanying ADR documents the per-fix calibration result (benchstat output, NDCG@10 delta, before/after wall-time numbers on a specific machine spec). One ADR per fix.
+- **Trigger B — Search latency reports from real users:** if an `mcp.Run` SDK author or `ken-mcp` operator reports search latency as actionable pain on a 100k+ chunk corpus, escalate the HNSW conversation (#4) from documented-future to active investigation. New ADR for the dep / implementation choice.
+- **Trigger C — Post-fix re-measurement:** after #1–#3 land, re-run the small + medium workloads. If embed accumulator (#5) is still >20% of indexing CPU, escalate to active SIMD investigation. If GC pressure stays the same (it should drop with #2's alloc reduction), something is wrong and we need to re-investigate.
+- **Trigger D — Large-scale measurement need:** any of (a) a regression check needs a large-scale baseline, (b) the chromium decision in the giant workload becomes a real product question (e.g., kubernetes-demo from `outputs/oss-demo-playbook.md` shows hybrid search behaving differently than medium predicted), (c) an SDK author reports binary-size or memory pain at large scale.
+- **Trigger E — gotreesitter upstream conversation:** when the open selective-grammar issue resolves (whether merged or rejected), the goodwill budget clears for the arena-optimization PR per `outputs/treesitter-port-considerations.md` Tier 2.
+
+---
+
+## Open questions deliberately not resolved here
+
+- ~~Exact share of `filePathPenalty` at medium scale.~~ **Resolved during draft review:** medium pprof showed `filePathPenalty` does not appear in the top 30 cumulative frames (cutoff <0.5%). ANN flat (78.56%) dominates so completely that the regex backtracking is lost in noise at production scale. `filePathPenalty` demoted from Ship tier accordingly; see hotspot table for the full reasoning.
+- **Why is per-chunk tokenizer allocation GROWING with corpus size?** 35 KB/chunk → 53 KB/chunk going small → medium isn't constant overhead per-chunk. Suggests the postings-list hashmap insertion is paying real cost as the vocabulary grows (more rehashing? more collision handling?). Worth a pprof read at the medium scale before fix #2 ships, to make sure the fix targets the actual hotspot.
+- **Where is the chromium-vs-synthetic decision for the "giant" workload row in `docs/PERF.md`?** Still TBD. Phase 1 didn't need to resolve it. Resolve when Trigger D fires.
+
+## Files this ADR's promotion will touch
+
+- `docs/DECISIONS.md` — append ADR-025; cross-link from ADR-010, ADR-011, ADR-016, ADR-023, ADR-024 summary table.
+- `docs/PERF.md` — populate "Empirical findings" section with the Phase 1 summary + cross-reference to this ADR. Fix the workload-table 19-vs-63-repos inconsistency. "Headline numbers" stays empty.
+- `outputs/treesitter-port-considerations.md` — already exists as the future-ADR seed. No edits needed; this ADR references it.
+
+CHANGELOG entry for the next release: ADR-025 lands as a docs-only commit. No code ships in this ADR; each follow-on fix gets its own commit + CHANGELOG entry.
 
 ---
 

--- a/docs/PERF.md
+++ b/docs/PERF.md
@@ -52,7 +52,7 @@ Four scales, each pinned to a specific revision. Adding a new workload means add
 | Scale | Corpus | Files (approx) | Pin | Why |
 | --- | --- | --- | --- | --- |
 | Small | ken itself | ~150 Go | HEAD on `perf-investigation` | Fast iteration; runs on a laptop in seconds; baseline. |
-| Medium | semble bench corpus | ~19 repos aggregate | `repos.json` revisions (upstream-pinned) | Same corpus as `docs/BENCH.md` NDCG runs; perf and quality numbers line up. |
+| Medium | semble bench corpus | ~80k files / 63 repos aggregate (~378k chunks indexed via regex) | `repos.json` revisions (upstream-pinned) | Same corpus as `docs/BENCH.md` NDCG runs; perf and quality numbers line up. |
 | Large | Linux kernel | ~80k files / ~30M LoC | `v6.10` tag | Real-world large monorepo; multiple languages; common code-search reference. |
 | Giant | TBD — chromium or synthetic | ~500k files | TBD | One-time landmark measurement for the "does the architecture hold at this scale?" question; not a routine re-run. |
 
@@ -95,7 +95,28 @@ The acceptance threshold for shipping a perf change is:
 
 ## Empirical findings
 
-*This section accumulates per-investigation findings the same way `docs/BENCH.md` accumulates per-version findings. The first investigation pass will land its outcome here, cross-referenced to ADR-025.*
+### Phase 1 (2026-05-26) — investigation pass against small + medium workloads
+
+See [ADR-025](DECISIONS.md#adr-025-perf-campaign-phase-1-investigation-outcome--hotspot-identification-across-small--medium-workloads) for the full hotspot ranking, decision categories, and triggers for follow-on work.
+
+**Caveats** — all numbers below are single-run on a single machine spec (Apple M1 Pro, native arm64 darwin / Go 1.26.3) and **are NOT publishable headlines** under the acceptance threshold in this file. They are investigation evidence; median-of-N + second-machine confirmation are required before any number lands in the "Headline numbers" section above.
+
+**Hotspot summary (from medium-scale CPU + alloc profiles):**
+
+- **ANN flat scan dominates hybrid search at scale.** `ann.Flat.Query` = 78.56% of hybrid-regex search CPU at medium (378,524 chunks). Inside that, the candidate-sort step (`sort.Slice` over all candidate scores to take K=10) is 30.88%. Min-heap-of-size-K refactor landed in v0.8.4 ([ADR-026](DECISIONS.md#adr-026-paired-heap-refactor-for-annflatquery--bm25indextopk-v084)).
+- **BM25 search top-K used sort instead of heap.** `bm25.Index.TopK` was 36% of bm25-regex search CPU at medium; all in `sort.Slice` / `pdqsort_func`. Sister refactor to the ANN fix; also landed in v0.8.4.
+- **BM25 tokenizer allocates ~45% of all indexing allocations.** `Tokenize.func1` + `camelSplit` + `Tokenize-range1` = 8.7 GB of 19.3 GB cumulative bm25-regex indexing allocations at medium. Per-chunk alloc grows from 35 KB (small) to 53 KB (medium) — not constant overhead; the cost grows with scale. Targeted by v0.8.5 (BM25 tokenizer alloc reduction); carries real NDCG-regression risk per the acceptance threshold.
+- **GC dominates CPU at medium scale.** ~50% of indexing CPU and ~36% of search CPU at medium goes to `runtime.gcBgMarkWorker` + `tryDeferToSpanScan` + `scanObject`. Direct consequence of the allocation pattern; reducing allocations (v0.8.5) reduces GC time proportionally.
+- **Tree-sitter chunker scales super-linearly.** Per-chunk arena allocation grows 6.4× small→medium (450 KB → 2.9 MB). 1.09 TB cumulative allocation to index 379k chunks via bm25-treesitter at medium. 37-minute wall time. This is an upstream gotreesitter concern, not in-tree fixable; documented in `outputs/treesitter-port-considerations.md`.
+- **`filePathPenalty` regex backtracking was a small-scale-only hotspot.** 24% of hybrid search CPU at small (1,560 chunks); <0.5% at medium. Not worth shipping a fix unless a small-corpus user reports actionable pain.
+
+**Predictions vs evidence** (Phase 1 ran with seven written-down predictions in `outputs/perf-investigation-plan.md`):
+
+- Confirmed: embed dominates indexing CPU (#1), BM25 tokenizer alloc-heavy (#2), ANN flat dominates search at scale (#3), file walk not hot (#4), parser pool not hot (#6).
+- Falsified: rerank not hot at k=20 (#7) — failed at small scale due to `filePathPenalty`; re-confirmed at medium where ANN-flat overwhelms rerank work.
+- New findings: GC dominates CPU at scale; tree-sitter super-linear per-chunk; `bm25.Index.TopK` + `ann.Flat.Query` both used sort-then-slice instead of heap-of-K (both fixed in v0.8.4).
+
+**Reproduction:** `scripts/perf_collect.sh small` for the small workload (~30s), `scripts/perf_collect.sh medium --modes=bm25,hybrid --chunkers=regex,treesitter` for the medium triage (~3 hours wall on M1 Pro native arm64; full cross-product is impractical — see [ADR-025](DECISIONS.md#adr-025-perf-campaign-phase-1-investigation-outcome--hotspot-identification-across-small--medium-workloads) for the methodology adjustment).
 
 ## Files
 

--- a/docs/PERF.md
+++ b/docs/PERF.md
@@ -1,0 +1,119 @@
+# Measuring ken's performance numbers
+
+ken's quality story is settled — NDCG@10 lands within the documented ±0.005 of semble (see [`docs/BENCH.md`](BENCH.md)). The perf story isn't yet: we have no published numbers, no measurement harness in-tree, and no documented methodology. This file is the calibration anchor for that work. It lands **before any number is collected**, so the methodology can't be retrofitted to flatter a conclusion.
+
+The discipline mirrors `docs/BENCH.md`'s shape: every claim ships with a reproducible command, a pinned workload, a machine spec, and a `benchstat`-style median-of-N run. "No metric drift" extends from quality to perf.
+
+## What it measures
+
+Four orthogonal dimensions:
+
+- **Indexing throughput.** Cold-index wall time, watch-mode incremental re-publish latency, allocation totals.
+- **Search latency.** Per-query wall time p50 / p95 / p99 over a large random query sample.
+- **Memory footprint.** Peak RSS during indexing, steady-state RSS after the index settles.
+- **Scale-out.** Does ken complete on a giant corpus (linux kernel, chromium-class)? If not, at what corpus size does it fail and how?
+
+Each dimension is measured across the three retrieval modes (`bm25` / `semantic` / `hybrid`) and the three chunkers (`regex` / `treesitter` / `line`) where the cross-product matters — `--mode bm25 --chunker line` is a different shape than `--mode hybrid --chunker treesitter` and we don't pretend a single number summarizes both.
+
+## Methodology
+
+**Harness.** `ken perf` is a sibling subcommand to `ken bench`. The split is deliberate: `bench` is the NDCG/quality harness (drives `scripts/bench_coir.py`); `perf` is the speed/memory harness (emits one JSON record per workload-run plus optional pprof profiles). Neither harness shares state with the other.
+
+```
+ken perf index  <path>  [--mode=...] [--chunker=...] [--cpuprofile=...] [--memprofile=...]
+ken perf search <path>  [--queries=FILE] [--n=1000] [--mode=...] [--chunker=...] [--cpuprofile=...]
+ken perf watch  <path>  [--edits=N] [--mode=...] [--chunker=...]
+```
+
+Each invocation emits a single JSON record on stdout with timing + RSS + alloc fields. `bench_out/<workload>/<date>/` collects records + profiles per run. Long-form analysis happens off-line with `pprof`, `benchstat`, and the JSON records.
+
+**Repeatability.** Every published number is the median of N runs (N=10 for quick metrics; N=3 for expensive end-to-end runs over giant corpora). `benchstat` confirms the variance is below the published claim's significant figure. Numbers that don't survive a re-run on a clean machine don't ship.
+
+**Machine spec.** Every number ships annotated with: machine (e.g., `M3 Pro 12-core / 36 GB`), Go toolchain (`go1.26.3`), build flags (`CGO_ENABLED=0`, `-trimpath -ldflags='-s -w'`), and the exact `ken perf …` invocation. A second machine spec re-runs the same numbers as a sanity check before publication.
+
+**Pinning.** The workload corpus is SHA-pinned (see Workloads below). Future re-runs against the same SHA produce comparable numbers; numbers against a different SHA are documented as a separate measurement.
+
+## Prerequisites
+
+- **`ken` built with race detector OFF and inlining ON.** Race-instrumented and debug builds skew CPU profiles. Use the same build flags goreleaser uses for releases.
+- **Go 1.26.3** matching `go.mod`'s `toolchain` directive.
+- **`benchstat`** for comparing multiple `go test -bench` runs:
+  ```bash
+  go install golang.org/x/perf/cmd/benchstat@latest
+  ```
+- **`pprof`** is bundled with Go; the web UI needs `graphviz` (`brew install graphviz` / `apt install graphviz`).
+- **For the medium workload (semble bench corpus):** same setup as `docs/BENCH.md` — semble checkout under `/tmp/semble`, corpus synced via `python benchmarks/sync_repos.py`, model at `~/.ken/model`.
+- **For large/giant workloads:** see Workloads below — each documents its own clone/download step.
+
+## Workloads
+
+Four scales, each pinned to a specific revision. Adding a new workload means adding a row here with its SHA pin, expected file count, expected indexing time order-of-magnitude, and a one-line reason it's in the corpus.
+
+| Scale | Corpus | Files (approx) | Pin | Why |
+| --- | --- | --- | --- | --- |
+| Small | ken itself | ~150 Go | HEAD on `perf-investigation` | Fast iteration; runs on a laptop in seconds; baseline. |
+| Medium | semble bench corpus | ~19 repos aggregate | `repos.json` revisions (upstream-pinned) | Same corpus as `docs/BENCH.md` NDCG runs; perf and quality numbers line up. |
+| Large | Linux kernel | ~80k files / ~30M LoC | `v6.10` tag | Real-world large monorepo; multiple languages; common code-search reference. |
+| Giant | TBD — chromium or synthetic | ~500k files | TBD | One-time landmark measurement for the "does the architecture hold at this scale?" question; not a routine re-run. |
+
+The giant-scale workload is deliberately marked TBD. Two options under consideration: real chromium clone (truthful but high bandwidth + slow to refresh), or a synthetic corpus generator that produces N files with realistic language mix and known token distribution (cheap and reproducible, loses real-world distribution character). The choice gets documented here before the first giant-scale number lands.
+
+## Run a measurement pass
+
+```bash
+# Small workload, all modes, all chunkers — fast smoke run (~30 s):
+scripts/perf_collect.sh small
+
+# Medium workload (~5 min):
+scripts/perf_collect.sh medium
+
+# Large workload (~20–60 min depending on hardware):
+scripts/perf_collect.sh large
+```
+
+Each invocation writes one record per (workload × mode × chunker) combination to `bench_out/<workload>/<date>/records.jsonl`, plus CPU/heap/alloc pprof profiles to `bench_out/<workload>/<date>/profiles/`. The script is idempotent — re-running overwrites the day's records.
+
+## Interpreting numbers
+
+A published number is meaningful only if a re-run on a clean machine with the same workload + machine spec lands within the published variance. `benchstat` makes this explicit:
+
+```bash
+benchstat bench_out/medium/2026-05-20/raw.txt bench_out/medium/2026-05-26/raw.txt
+```
+
+`p < 0.05` means the two runs are statistically different. We don't ship "X% faster" claims that don't pass benchstat at `p < 0.05` against a baseline measured the same week on the same machine.
+
+The acceptance threshold for shipping a perf change is:
+
+1. The change is statistically significant per benchstat (`p < 0.05`).
+2. The change holds on a second machine spec (different CPU family / different OS) — guards against single-machine artifacts.
+3. NDCG@10 on the semble bench corpus is unchanged within `docs/BENCH.md`'s ±0.005 window. Perf changes that regress retrieval quality don't ship without an explicit calibration-discipline ADR documenting the trade.
+
+## Headline numbers
+
+*This section is empty until the first measurement pass completes. Numbers land here with their machine spec, command, and reproduction recipe inline — no separate appendix that can drift from the headlines.*
+
+## Empirical findings
+
+*This section accumulates per-investigation findings the same way `docs/BENCH.md` accumulates per-version findings. The first investigation pass will land its outcome here, cross-referenced to ADR-025.*
+
+## Files
+
+Landed:
+
+- `internal/perf/` — measurement helpers: `LatencyStats` (p50/p95/p99/min/max/mean over `[]time.Duration`), `AllocSnapshot` (runtime.MemStats delta), `HeapSnapshot` (Go-runtime view of HeapInuse/HeapSys/Sys; OS-level peak RSS still needs `/usr/bin/time -v`).
+- `cmd/ken/perf.go` — the `ken perf` subcommand dispatch + `perf index` / `perf search` / `perf watch` implementations. Each emits one JSON record per invocation; `index` + `search` also accept `--cpuprofile FILE` / `--memprofile FILE`. Sibling to `ken bench` (NDCG/quality harness); the two share no state.
+  - `perf index` — measures cold-index wall time + alloc delta + heap.
+  - `perf search` — `--queries FILE` (same `'#' comments + blank lines skipped` format as `ken bench` stdin) + `--n N` (sample size; cycles through the file's queries until N samples collected); emits LatencyStats + alloc-per-query.
+  - `perf watch` — `--edits N` (default 10); copies the corpus to a temp dir, opens a WatchedIndex with `SetOnFlush` as the rebuild-completed hook, mutates a target file N times, measures end-to-end edit → flush latency. The v0.3 debouncer (default 2s, ADR-012) dominates and that's the right thing to measure — users see this latency.
+
+- `internal/bm25/bm25_bench_test.go` — `BenchmarkTokenize` over a real Go source file (ken's own `internal/search/index.go`; skips if not found); `BenchmarkScore/N100` and `BenchmarkScore/N1000` over a synthetic line-grouped corpus built from the same source. Every benchmark calls `b.ReportAllocs()` and `b.SetBytes()` where meaningful. Targets prediction #2 (BM25 tokenizer allocates heavily) and #3 baseline (BM25 score at the small/medium sizes the rest of the search pipeline feeds it).
+- `internal/embed/embed_bench_test.go` — `BenchmarkInferOne` (single ~50-line chunk) and `BenchmarkInferBatch` (1000 distinct chunks, single model load, so amortised per-call cost reads off the batch throughput). Both `b.Skip()` if `testdata/model/` is absent (mirrors the existing parity / golden tests). `b.SetBytes()` reports MB/s of embedding throughput. Targets prediction #1 (embed inference dominates indexing CPU time).
+- `internal/ann/ann_bench_test.go` — `BenchmarkFlatQuery/N1k`, `/N10k`, `/N50k` (table-driven via `b.Run`). Synthetic L2-normalized vectors at `dim=128` (Model2Vec's potion-code-16M output dim) with a seeded PRNG so runs are deterministic across hosts. `b.SetBytes()` reports flat-scan memory bandwidth (N × dim × 4 B per query). Max N is 50k rather than the briefing's 100k — judgment call to keep a single iteration under a couple seconds on a laptop; Phase 1 can bump back up on better hardware. Targets prediction #3 (flat search becomes intractable at chromium scale).
+- `internal/chunk/regex/chunker_bench_test.go` + `internal/chunk/treesitter/cast_bench_test.go` — `BenchmarkChunker_Go` / `_TypeScript` / `_Python` (regex side) and `BenchmarkCAST_Go` / `_TypeScript` / `_Python` (treesitter side). Identical fixture per language so a Phase-1 benchstat run can diff regex-vs-treesitter throughput directly: Go = ken's own `internal/search/index.go`; TS + Py = `testdata/repo/widget.ts` / `auth.py` (smaller but real — no larger TS/Py fixtures are checked in outside the COIR bench corpus). The treesitter benchmarks include a warm-up call before `ResetTimer` to amortise first-call parser-pool init (ADR-010).
+- `internal/search/rerank_bench_test.go` — `BenchmarkRerank/Symbol` and `/NaturalLang` over a synthetic 100-chunk × 20-file corpus with realistic Go-method shapes. Two query types because `applyQueryBoost` branches on `isSymbolQuery(query)` — the symbol path runs `boostSymbolDefinitions`, the natural-language path runs `boostStemMatches` + `boostEmbeddedSymbols`. Falsifies (or doesn't) briefing prediction #7 (rerank is NOT a hotspot at k=20).
+- `internal/repo/walk_bench_test.go` — `BenchmarkWalkFS/N100`, `/N1k`, `/N10k` over a synthetic tree spread across N/100 subdirectories. Max N is 10k rather than the briefing's 100k — judgment call to keep setup time bounded (10k files takes ~1 s on a fast SSD; 100k would be ~10×). Targets briefing prediction #4 (file walk is NOT a bottleneck relative to per-file parse + embed).
+- `scripts/perf_collect.sh` — bash workload-collection wrapper. Takes one positional arg (`small` / `medium` / `large` / `giant` / `all`) plus optional `--modes=LIST` and `--chunkers=LIST` filters (comma-separated subsets of `{bm25,semantic,hybrid}` / `{regex,treesitter,line}`; default is the full 3×3 matrix). Drives `ken perf index` + `ken perf search` across the selected mode × chunker subset, wraps each invocation in `gtime -v` (macOS, via `brew install gnu-time`) or `/usr/bin/time -v` (Linux) for truthful OS-level peak RSS, captures pprof CPU + heap profiles, writes everything under `bench_out/<workload>/<date>/`. Each run emits a `meta.json` header (uname / go version / ken commit / build flags / start+end timestamps / `modes_run` + `chunkers_run` so downstream analysis can distinguish a filtered run from a full matrix), one JSON record per `(mode × chunker × {index,search})` appended to `records.jsonl`, and pprof profiles under `profiles/`. Workload paths default to the conventional locations and are overridable via `WORKLOAD_MEDIUM` / `WORKLOAD_LARGE`; `giant` is currently a stub pending the Phase-1 corpus-choice decision. Default query set for `perf search` is a small built-in list; override with `PERF_QUERIES=FILE`. Filter examples: `--modes=bm25` (skip semantic+hybrid; re-running after a chunker fix without paying embed cost), `--chunkers=regex,line` (skip the slow treesitter pass), `--modes=bm25 --chunkers=regex` (smoke pass — 1×1 = 2 invocations per workload, makes `large` + `giant` tractable).
+- `bench_out/` — per-workload, per-date output directory. Not committed (added to `.gitignore` alongside `outputs/`); reproducible from the methodology above, so we don't carry raw outputs in version control.
+
+The full perf harness is now in tree. Phase 1 runs measurements against it.

--- a/internal/chunk/regex/chunker_bench_test.go
+++ b/internal/chunk/regex/chunker_bench_test.go
@@ -1,0 +1,55 @@
+package regex
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/townsendmerino/ken/internal/chunk"
+)
+
+// loadFixture reads a real source file from this repo. The Go fixture
+// (ken's own internal/search/index.go) is the same one BM25 / embed
+// benchmarks use — non-trivial size (~30KB, 650 lines). The TypeScript
+// and Python fixtures come from testdata/repo/, which are smaller (~25
+// lines each) but real — there are no larger TS/Py files checked in
+// outside the COIR bench corpus, and reaching into that would couple
+// the chunker benchmarks to bench data they don't otherwise share.
+// Briefing judgment call #5: documented the choice in this comment +
+// the commit message.
+func loadFixture(b *testing.B, relPath string) []byte {
+	b.Helper()
+	data, err := os.ReadFile(relPath)
+	if err != nil {
+		b.Skipf("fixture not found at %s: %v", relPath, err)
+	}
+	return data
+}
+
+func benchChunk(b *testing.B, lang string, source []byte) {
+	c := New()
+	b.SetBytes(int64(len(source)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := c.Chunk(source, lang, chunk.DefaultChunkSize)
+		if err != nil {
+			b.Fatalf("Chunk: %v", err)
+		}
+	}
+}
+
+func BenchmarkChunker_Go(b *testing.B) {
+	src := loadFixture(b, filepath.Join("..", "..", "search", "index.go"))
+	benchChunk(b, "go", src)
+}
+
+func BenchmarkChunker_TypeScript(b *testing.B) {
+	src := loadFixture(b, filepath.Join("..", "..", "..", "testdata", "repo", "widget.ts"))
+	benchChunk(b, "typescript", src)
+}
+
+func BenchmarkChunker_Python(b *testing.B) {
+	src := loadFixture(b, filepath.Join("..", "..", "..", "testdata", "repo", "auth.py"))
+	benchChunk(b, "python", src)
+}

--- a/internal/chunk/treesitter/cast_bench_test.go
+++ b/internal/chunk/treesitter/cast_bench_test.go
@@ -1,0 +1,59 @@
+package treesitter
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/townsendmerino/ken/internal/chunk"
+)
+
+// loadFixture is the same realistic-input pattern as the regex chunker's
+// benchmark — see internal/chunk/regex/chunker_bench_test.go for the
+// fixture-choice rationale (Go = ken's own internal/search/index.go;
+// TS + Py = testdata/repo/* small but real). Using the same files lets
+// a Phase-1 benchstat run directly diff regex-vs-treesitter per-language
+// throughput on identical input.
+func loadFixture(b *testing.B, relPath string) []byte {
+	b.Helper()
+	data, err := os.ReadFile(relPath)
+	if err != nil {
+		b.Skipf("fixture not found at %s: %v", relPath, err)
+	}
+	return data
+}
+
+func benchChunk(b *testing.B, lang string, source []byte) {
+	c := New()
+	// Warm up: first call materialises the parser pool entry for this
+	// language (gotreesitter allocates a fresh parser on first use).
+	// We want to measure steady-state cAST cost, not first-call pool
+	// init, so do one call before ResetTimer.
+	if _, err := c.Chunk(source, lang, chunk.DefaultChunkSize); err != nil {
+		b.Fatalf("warm-up Chunk: %v", err)
+	}
+	b.SetBytes(int64(len(source)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := c.Chunk(source, lang, chunk.DefaultChunkSize)
+		if err != nil {
+			b.Fatalf("Chunk: %v", err)
+		}
+	}
+}
+
+func BenchmarkCAST_Go(b *testing.B) {
+	src := loadFixture(b, filepath.Join("..", "..", "search", "index.go"))
+	benchChunk(b, "go", src)
+}
+
+func BenchmarkCAST_TypeScript(b *testing.B) {
+	src := loadFixture(b, filepath.Join("..", "..", "..", "testdata", "repo", "widget.ts"))
+	benchChunk(b, "typescript", src)
+}
+
+func BenchmarkCAST_Python(b *testing.B) {
+	src := loadFixture(b, filepath.Join("..", "..", "..", "testdata", "repo", "auth.py"))
+	benchChunk(b, "python", src)
+}

--- a/internal/embed/embed_bench_test.go
+++ b/internal/embed/embed_bench_test.go
@@ -1,0 +1,104 @@
+package embed
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// modelDirForBench resolves testdata/model/ (the per-machine, not-committed
+// model snapshot). Skip pattern mirrors internal/embed/parity_test.go +
+// internal/embed/golden_test.go: a fresh checkout has no model and the
+// benchmark must not fail there.
+func modelDirForBench(b *testing.B) string {
+	b.Helper()
+	dir := filepath.Join("..", "..", "testdata", "model")
+	if _, err := os.Stat(filepath.Join(dir, "model.safetensors")); err != nil {
+		b.Skip("testdata/model/ not present; see testdata/README.md")
+	}
+	return dir
+}
+
+// loadBenchSource reads a real Go file from this repo for inference
+// input. Uses internal/search/index.go for the same reason BM25's
+// benchmarks do — non-trivial size, realistic identifier shapes,
+// always checked in.
+func loadBenchSource(b *testing.B) string {
+	b.Helper()
+	data, err := os.ReadFile(filepath.Join("..", "search", "index.go"))
+	if err != nil {
+		b.Skipf("source not found: %v", err)
+	}
+	return string(data)
+}
+
+// chunkSource splits src into approximately N equal pieces by line count.
+// Used so BenchmarkInferBatch has a realistic batch of distinct chunks
+// rather than 1000 copies of the same string (which the runtime/CPU might
+// optimise unrealistically well).
+func chunkSource(src string, n int) []string {
+	lines := strings.Split(src, "\n")
+	if n <= 0 {
+		n = 1
+	}
+	per := len(lines) / n
+	if per < 1 {
+		per = 1
+	}
+	out := make([]string, 0, n)
+	for i := 0; i < n && i*per < len(lines); i++ {
+		end := (i + 1) * per
+		if end > len(lines) {
+			end = len(lines)
+		}
+		out = append(out, strings.Join(lines[i*per:end], "\n"))
+	}
+	return out
+}
+
+func BenchmarkInferOne(b *testing.B) {
+	m, err := Load(modelDirForBench(b))
+	if err != nil {
+		b.Fatalf("Load: %v", err)
+	}
+	// A single representative chunk. Take the first ~50 lines of the
+	// source file — comparable to one chunker output in steady state.
+	chunks := chunkSource(loadBenchSource(b), 50)
+	if len(chunks) == 0 {
+		b.Skip("no chunks built from source")
+	}
+	text := chunks[0]
+	b.SetBytes(int64(len(text)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = m.Encode(text)
+	}
+}
+
+func BenchmarkInferBatch(b *testing.B) {
+	m, err := Load(modelDirForBench(b))
+	if err != nil {
+		b.Fatalf("Load: %v", err)
+	}
+	const batchSize = 1000
+	chunks := chunkSource(loadBenchSource(b), batchSize)
+	if len(chunks) == 0 {
+		b.Skip("no chunks built from source")
+	}
+	// Aggregate bytes across the batch so SetBytes reflects total work,
+	// not per-call work. benchstat MB/s thus reads as embedding throughput.
+	var totalBytes int64
+	for _, c := range chunks {
+		totalBytes += int64(len(c))
+	}
+	b.SetBytes(totalBytes)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for _, c := range chunks {
+			_ = m.Encode(c)
+		}
+	}
+}

--- a/internal/perf/perf.go
+++ b/internal/perf/perf.go
@@ -1,0 +1,142 @@
+// Package perf is the measurement-helper library backing `ken perf` and
+// `scripts/perf_collect.sh`. Three responsibilities:
+//
+//   - LatencyStats over a []time.Duration sample (p50/p95/p99/min/max/mean).
+//   - AllocSnapshot wrapping runtime.MemStats deltas (bytes + objects).
+//   - HeapSnapshot for the Go-runtime view of live + reserved memory.
+//
+// All three types are JSON-marshallable so `ken perf {index,search,watch}`
+// can emit a single record per invocation that benchstat / pprof / ad-hoc
+// shell tooling consumes downstream.
+//
+// Note on RSS: HeapSnapshot reports the *Go runtime* view only. The
+// truthful OS-level peak RSS comes from wrapping the binary in
+// `/usr/bin/time -v` (or `gtime -v` on macOS) at the shell level —
+// `scripts/perf_collect.sh` does that.
+package perf
+
+import (
+	"runtime"
+	"sort"
+	"time"
+)
+
+// LatencyStats summarises a sample of durations. Marshalled in milliseconds
+// (float64) so the JSON record is human-readable and benchstat-friendly;
+// nanosecond precision via time.Duration is retained at compute time.
+type LatencyStats struct {
+	N      int     `json:"n"`
+	MinMs  float64 `json:"min_ms"`
+	MaxMs  float64 `json:"max_ms"`
+	MeanMs float64 `json:"mean_ms"`
+	P50Ms  float64 `json:"p50_ms"`
+	P95Ms  float64 `json:"p95_ms"`
+	P99Ms  float64 `json:"p99_ms"`
+}
+
+// LatencyOf computes LatencyStats from a sample. The sample is sorted
+// in-place (caller-visible side effect; nearly always fine since the
+// caller built the slice for measurement and discards it). Empty sample
+// returns the zero value.
+//
+// Percentile convention: nearest-rank, 1-indexed. P50 of N=10 is the
+// 5th element (index 4). Matches what benchstat / hdr-histogram do and
+// avoids the off-by-one P95-of-N=20-is-the-19th-element trap.
+func LatencyOf(sample []time.Duration) LatencyStats {
+	n := len(sample)
+	if n == 0 {
+		return LatencyStats{}
+	}
+	sort.Slice(sample, func(i, j int) bool { return sample[i] < sample[j] })
+	toMs := func(d time.Duration) float64 { return float64(d.Microseconds()) / 1000.0 }
+	idx := func(p float64) int {
+		// nearest-rank 1-indexed: ceil(p * n) - 1, clamped to [0, n-1].
+		i := int((p*float64(n))+0.999999) - 1
+		if i < 0 {
+			i = 0
+		}
+		if i >= n {
+			i = n - 1
+		}
+		return i
+	}
+	var sum time.Duration
+	for _, d := range sample {
+		sum += d
+	}
+	return LatencyStats{
+		N:      n,
+		MinMs:  toMs(sample[0]),
+		MaxMs:  toMs(sample[n-1]),
+		MeanMs: toMs(sum) / float64(n),
+		P50Ms:  toMs(sample[idx(0.50)]),
+		P95Ms:  toMs(sample[idx(0.95)]),
+		P99Ms:  toMs(sample[idx(0.99)]),
+	}
+}
+
+// AllocSnapshot captures runtime.MemStats's cumulative TotalAlloc +
+// Mallocs at a point in time. Compare two via Delta() to get bytes +
+// objects allocated between the two snapshots; both fields are
+// monotonic so the subtraction is always non-negative.
+//
+// runtime.GC() is intentionally NOT called inside StartAlloc — the
+// caller decides whether to GC first (a fresh GC stabilises the
+// post-snapshot heap but takes wall time the caller may not want to
+// pay).
+type AllocSnapshot struct {
+	totalAlloc uint64 // cumulative bytes ever allocated
+	mallocs    uint64 // cumulative object allocations
+}
+
+// StartAlloc captures the current cumulative allocation counters.
+// Use Delta() on a later snapshot to compute allocations since.
+func StartAlloc() AllocSnapshot {
+	var m runtime.MemStats
+	runtime.ReadMemStats(&m)
+	return AllocSnapshot{totalAlloc: m.TotalAlloc, mallocs: m.Mallocs}
+}
+
+// AllocDelta is the bytes + objects allocated between two AllocSnapshots.
+type AllocDelta struct {
+	BytesAllocated   uint64 `json:"bytes_allocated"`
+	ObjectsAllocated uint64 `json:"objects_allocated"`
+}
+
+// Delta returns the allocation delta from s to the current MemStats.
+// runtime.MemStats counters are monotonic, so the subtraction never
+// underflows in a single process.
+func (s AllocSnapshot) Delta() AllocDelta {
+	var m runtime.MemStats
+	runtime.ReadMemStats(&m)
+	return AllocDelta{
+		BytesAllocated:   m.TotalAlloc - s.totalAlloc,
+		ObjectsAllocated: m.Mallocs - s.mallocs,
+	}
+}
+
+// HeapStats is the Go-runtime view of memory in use. NOT a substitute
+// for OS-level peak RSS — that requires `/usr/bin/time -v` (Linux) or
+// `gtime -v` (macOS) wrapping the binary. The fields below are the
+// subset of runtime.MemStats worth publishing in a `ken perf` record:
+//
+//   - HeapInuseBytes:   bytes in in-use heap spans (live working set).
+//   - HeapSysBytes:     bytes reserved from the OS for the heap (high-water).
+//   - SysBytes:         total bytes reserved by the Go runtime (heap+stack+other).
+type HeapStats struct {
+	HeapInuseBytes uint64 `json:"heap_inuse_bytes"`
+	HeapSysBytes   uint64 `json:"heap_sys_bytes"`
+	SysBytes       uint64 `json:"sys_bytes"`
+}
+
+// HeapSnapshot reads the current MemStats and returns the publishable
+// subset. Cheap; safe to call repeatedly.
+func HeapSnapshot() HeapStats {
+	var m runtime.MemStats
+	runtime.ReadMemStats(&m)
+	return HeapStats{
+		HeapInuseBytes: m.HeapInuse,
+		HeapSysBytes:   m.HeapSys,
+		SysBytes:       m.Sys,
+	}
+}

--- a/internal/perf/perf_test.go
+++ b/internal/perf/perf_test.go
@@ -1,0 +1,167 @@
+package perf
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+func TestLatencyOf_Empty(t *testing.T) {
+	got := LatencyOf(nil)
+	if got != (LatencyStats{}) {
+		t.Fatalf("LatencyOf(nil) = %+v, want zero value", got)
+	}
+	got = LatencyOf([]time.Duration{})
+	if got != (LatencyStats{}) {
+		t.Fatalf("LatencyOf([]) = %+v, want zero value", got)
+	}
+}
+
+func TestLatencyOf_Single(t *testing.T) {
+	got := LatencyOf([]time.Duration{5 * time.Millisecond})
+	want := LatencyStats{N: 1, MinMs: 5, MaxMs: 5, MeanMs: 5, P50Ms: 5, P95Ms: 5, P99Ms: 5}
+	if got != want {
+		t.Fatalf("LatencyOf({5ms}) = %+v, want %+v", got, want)
+	}
+}
+
+func TestLatencyOf_AllSame(t *testing.T) {
+	sample := make([]time.Duration, 100)
+	for i := range sample {
+		sample[i] = 7 * time.Millisecond
+	}
+	got := LatencyOf(sample)
+	if got.MinMs != 7 || got.MaxMs != 7 || got.P50Ms != 7 || got.P95Ms != 7 || got.P99Ms != 7 || got.MeanMs != 7 {
+		t.Fatalf("LatencyOf(all-7ms) = %+v, want all 7ms", got)
+	}
+	if got.N != 100 {
+		t.Fatalf("N = %d, want 100", got.N)
+	}
+}
+
+func TestLatencyOf_Percentiles(t *testing.T) {
+	// Sorted sample 1..100 ms. nearest-rank 1-indexed:
+	//   P50 of 100 = index 49 = 50ms
+	//   P95 of 100 = index 94 = 95ms
+	//   P99 of 100 = index 98 = 99ms
+	sample := make([]time.Duration, 100)
+	for i := range sample {
+		sample[i] = time.Duration(i+1) * time.Millisecond
+	}
+	got := LatencyOf(sample)
+	if got.P50Ms != 50 {
+		t.Errorf("P50 = %v, want 50ms", got.P50Ms)
+	}
+	if got.P95Ms != 95 {
+		t.Errorf("P95 = %v, want 95ms", got.P95Ms)
+	}
+	if got.P99Ms != 99 {
+		t.Errorf("P99 = %v, want 99ms", got.P99Ms)
+	}
+	if got.MinMs != 1 || got.MaxMs != 100 {
+		t.Errorf("min/max = %v/%v, want 1/100", got.MinMs, got.MaxMs)
+	}
+	if got.MeanMs != 50.5 {
+		t.Errorf("mean = %v, want 50.5", got.MeanMs)
+	}
+}
+
+func TestLatencyOf_Unsorted(t *testing.T) {
+	// LatencyOf sorts in place; pass an out-of-order sample and check the
+	// percentiles still come out right.
+	sample := []time.Duration{
+		10 * time.Millisecond,
+		1 * time.Millisecond,
+		5 * time.Millisecond,
+		3 * time.Millisecond,
+		7 * time.Millisecond,
+	}
+	got := LatencyOf(sample)
+	if got.MinMs != 1 || got.MaxMs != 10 {
+		t.Errorf("min/max = %v/%v, want 1/10", got.MinMs, got.MaxMs)
+	}
+	// P50 of 5: nearest-rank index ceil(0.5*5)-1 = 2 → sorted[2] = 5ms.
+	if got.P50Ms != 5 {
+		t.Errorf("P50 = %v, want 5ms", got.P50Ms)
+	}
+}
+
+func TestLatencyStats_JSON(t *testing.T) {
+	s := LatencyStats{N: 3, MinMs: 1, MaxMs: 3, MeanMs: 2, P50Ms: 2, P95Ms: 3, P99Ms: 3}
+	b, err := json.Marshal(s)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	var back LatencyStats
+	if err := json.Unmarshal(b, &back); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if back != s {
+		t.Fatalf("round-trip = %+v, want %+v", back, s)
+	}
+}
+
+func TestAllocSnapshot_Delta(t *testing.T) {
+	start := StartAlloc()
+	// Allocate ~1 MiB in known-sized objects so the delta is non-zero.
+	const n = 1024
+	keep := make([][]byte, n)
+	for i := range keep {
+		keep[i] = make([]byte, 1024)
+	}
+	d := start.Delta()
+	if d.BytesAllocated == 0 {
+		t.Fatalf("BytesAllocated = 0, want > 0")
+	}
+	if d.ObjectsAllocated == 0 {
+		t.Fatalf("ObjectsAllocated = 0, want > 0")
+	}
+	// Keep `keep` reachable so the compiler doesn't elide the allocs.
+	if len(keep) != n {
+		t.Fatal("unreachable")
+	}
+}
+
+func TestAllocDelta_JSON(t *testing.T) {
+	d := AllocDelta{BytesAllocated: 4096, ObjectsAllocated: 16}
+	b, err := json.Marshal(d)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if string(b) != `{"bytes_allocated":4096,"objects_allocated":16}` {
+		t.Fatalf("Marshal = %s", b)
+	}
+}
+
+func TestHeapSnapshot_NonZero(t *testing.T) {
+	h := HeapSnapshot()
+	// A running Go program always has non-zero HeapInuse / HeapSys / Sys.
+	if h.HeapInuseBytes == 0 {
+		t.Errorf("HeapInuseBytes = 0")
+	}
+	if h.HeapSysBytes == 0 {
+		t.Errorf("HeapSysBytes = 0")
+	}
+	if h.SysBytes == 0 {
+		t.Errorf("SysBytes = 0")
+	}
+	// Sys is the total runtime reservation; should be >= HeapSys.
+	if h.SysBytes < h.HeapSysBytes {
+		t.Errorf("SysBytes (%d) < HeapSysBytes (%d)", h.SysBytes, h.HeapSysBytes)
+	}
+}
+
+func TestHeapStats_JSON(t *testing.T) {
+	h := HeapStats{HeapInuseBytes: 1 << 20, HeapSysBytes: 2 << 20, SysBytes: 4 << 20}
+	b, err := json.Marshal(h)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	var back HeapStats
+	if err := json.Unmarshal(b, &back); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if back != h {
+		t.Fatalf("round-trip = %+v, want %+v", back, h)
+	}
+}

--- a/internal/repo/walk_bench_test.go
+++ b/internal/repo/walk_bench_test.go
@@ -1,0 +1,81 @@
+package repo
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// buildSyntheticTree creates a temporary directory containing numFiles
+// regular files spread across numFiles/100 subdirectories. Each file gets
+// a small ASCII payload so the binary-sniff fast-path completes without
+// rejecting the file. Returns the root path; cleanup is deferred via
+// b.Cleanup.
+//
+// Setup happens outside the b.N loop (b.ResetTimer is the caller's
+// responsibility). Even so, larger N causes meaningful disk I/O at
+// setup time — 10k files ≈ 0.5–1 s on a fast SSD; 100k would be ~10×
+// that and slows the bench dev loop, so the max is capped at 10k here.
+// Phase-1 hardware can extend the curve.
+func buildSyntheticTree(b *testing.B, numFiles int) string {
+	b.Helper()
+	root := b.TempDir()
+	const payload = "package x\n\nfunc Hi() string { return \"hi\" }\n"
+	dirsTotal := numFiles / 100
+	if dirsTotal < 1 {
+		dirsTotal = 1
+	}
+	// Pre-create every subdirectory so the WriteFile loop never races
+	// the directory existence check.
+	for d := 0; d < dirsTotal; d++ {
+		if err := os.MkdirAll(filepath.Join(root, fmt.Sprintf("dir%04d", d)), 0o755); err != nil {
+			b.Fatalf("mkdir: %v", err)
+		}
+	}
+	for i := 0; i < numFiles; i++ {
+		dir := filepath.Join(root, fmt.Sprintf("dir%04d", i%dirsTotal))
+		path := filepath.Join(dir, fmt.Sprintf("file%06d.go", i))
+		if err := os.WriteFile(path, []byte(payload), 0o644); err != nil {
+			b.Fatalf("write %s: %v", path, err)
+		}
+	}
+	return root
+}
+
+// BenchmarkWalkFS exercises gitignore-respecting walk + binary sniff +
+// size cap over synthetic trees of N=100/1k/10k files. Targets briefing
+// prediction #4 — file walk is NOT a bottleneck relative to per-file
+// parse + embed. If profiling shows otherwise at scale, this is the
+// canary that surfaces it.
+func BenchmarkWalkFS(b *testing.B) {
+	cases := []struct {
+		name string
+		n    int
+	}{
+		{"N100", 100},
+		{"N1k", 1_000},
+		{"N10k", 10_000},
+	}
+	for _, tc := range cases {
+		b.Run(tc.name, func(b *testing.B) {
+			root := buildSyntheticTree(b, tc.n)
+			fsys := os.DirFS(root)
+			// SetBytes lets benchstat report "files/s" indirectly via
+			// MB/s (with a fixed "bytes" interpretation = file count).
+			// Use the count so the unit is interpretable.
+			b.SetBytes(int64(tc.n))
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				files, err := WalkFS(fsys, Options{})
+				if err != nil {
+					b.Fatalf("WalkFS: %v", err)
+				}
+				if len(files) != tc.n {
+					b.Fatalf("WalkFS returned %d files, want %d", len(files), tc.n)
+				}
+			}
+		})
+	}
+}

--- a/internal/search/rerank_bench_test.go
+++ b/internal/search/rerank_bench_test.go
@@ -1,0 +1,85 @@
+package search
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/townsendmerino/ken/internal/chunk"
+)
+
+// buildRerankCorpus builds a synthetic chunks slice with realistic shape:
+// `numFiles` files × `chunksPerFile` chunks each. The chunk text contains
+// Go-like func/method definitions so the boost passes (which scan for
+// definition keywords like `func`, `class`, `def`) hit realistic
+// code paths.
+func buildRerankCorpus(numFiles, chunksPerFile int) []chunk.Chunk {
+	out := make([]chunk.Chunk, 0, numFiles*chunksPerFile)
+	for f := 0; f < numFiles; f++ {
+		file := fmt.Sprintf("pkg/sub%d/file%d.go", f%5, f)
+		for c := 0; c < chunksPerFile; c++ {
+			start := c*40 + 1
+			text := fmt.Sprintf(`package sub%d
+
+// Symbol%d_%d does something interesting.
+func Symbol%d_%d(ctx Context, name string) (*Result, error) {
+	if name == "" {
+		return nil, ErrEmpty
+	}
+	return process(ctx, name)
+}
+`, f%5, f, c, f, c)
+			out = append(out, chunk.Chunk{
+				File:      file,
+				StartLine: start,
+				EndLine:   start + 8,
+				Text:      text,
+			})
+		}
+	}
+	return out
+}
+
+// buildFusedScores synthesises a post-fusion candidate map with RRF-style
+// scores (1/(k+rank), k=60). nCandidates is the count semble's hybrid
+// produces — k=20 final × candidateCount=5×k = 100 candidates flowing
+// into rerank.
+func buildFusedScores(corpusLen, nCandidates int) map[int]float64 {
+	if nCandidates > corpusLen {
+		nCandidates = corpusLen
+	}
+	out := make(map[int]float64, nCandidates)
+	for rank := 1; rank <= nCandidates; rank++ {
+		out[rank-1] = 1.0 / float64(60+rank)
+	}
+	return out
+}
+
+// BenchmarkRerank exercises the boost + penalty + saturation pipeline that
+// hybridSearch invokes after RRF fusion. Two query shapes — a symbol-like
+// query (single identifier; isSymbolQuery → true; takes the
+// boostSymbolDefinitions path) and a natural-language query (takes the
+// boostStemMatches + boostEmbeddedSymbols path).
+//
+// Briefing prediction #7 says rerank is NOT a hotspot at k=20; this
+// benchmark is its falsifier.
+func BenchmarkRerank(b *testing.B) {
+	chunks := buildRerankCorpus(20, 5) // 100 chunks total
+	fused := buildFusedScores(len(chunks), 100)
+	cases := []struct {
+		name  string
+		query string
+	}{
+		{"Symbol", "Symbol0_0"},
+		{"NaturalLang", "build index from path"},
+	}
+	for _, tc := range cases {
+		b.Run(tc.name, func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				boosted := applyQueryBoost(fused, tc.query, chunks)
+				_ = rerankTopK(boosted, chunks, 20, true)
+			}
+		})
+	}
+}

--- a/scripts/perf_collect.sh
+++ b/scripts/perf_collect.sh
@@ -1,0 +1,338 @@
+#!/usr/bin/env bash
+# scripts/perf_collect.sh — workload collection wrapper for `ken perf`.
+#
+# Drives `ken perf index` + `ken perf search` across the full
+# (mode × chunker) cross-product for one workload, wraps each
+# invocation in /usr/bin/time -v (Linux) / gtime -v (macOS via
+# `brew install gnu-time`) for truthful OS-level peak RSS, captures
+# pprof CPU + heap profiles, and writes everything to
+# bench_out/<workload>/<date>/.
+#
+# Usage:
+#   scripts/perf_collect.sh [flags] WORKLOAD
+#
+# WORKLOAD:
+#   small    # ken itself (sub-second iteration)
+#   medium   # ~/.cache/semble-bench (matches docs/BENCH.md corpus)
+#   large    # Linux kernel checkout at v6.10 (see WORKLOAD_LARGE)
+#   giant    # currently a stub — see docs/PERF.md Workloads
+#   all      # small + medium + large in sequence
+#
+# Flags:
+#   --modes=LIST       Comma-separated subset of {bm25,semantic,hybrid}. Default: all.
+#   --chunkers=LIST    Comma-separated subset of {regex,treesitter,line}. Default: all.
+#
+# Examples:
+#   scripts/perf_collect.sh medium                            # full 3×3 matrix (18 invocations)
+#   scripts/perf_collect.sh medium --modes=bm25               # bm25-only (6 invocations)
+#   scripts/perf_collect.sh large --chunkers=regex,line       # skip slow treesitter (12 invocations)
+#   scripts/perf_collect.sh all --modes=bm25 --chunkers=regex # smoke pass across every workload
+#
+# Workload sources:
+#   small  — uses $PWD (the ken repo HEAD checkout). No setup needed.
+#   medium — uses ${WORKLOAD_MEDIUM:-$HOME/.cache/semble-bench}.
+#            Bootstrap per docs/BENCH.md:
+#              git clone https://github.com/MinishLab/semble /tmp/semble
+#              cd /tmp/semble && uv sync && python benchmarks/sync_repos.py
+#   large  — uses ${WORKLOAD_LARGE:-$HOME/.cache/linux-v6.10}.
+#            Bootstrap:
+#              git clone --depth 1 --branch v6.10 \
+#                https://github.com/torvalds/linux $HOME/.cache/linux-v6.10
+#   giant  — stub; requires chromium or equivalent. The corpus choice
+#            is Phase-1 territory; see docs/PERF.md Workloads for the
+#            chromium-vs-synthetic discussion.
+#
+# Per-invocation outputs (under bench_out/<workload>/<date>/):
+#   meta.json                                  — machine + go + ken-commit + start/end
+#   records.jsonl                              — one `ken perf` JSON record per line
+#   <mode>-<chunker>.index.gtime               — /usr/bin/time -v output (RSS truth)
+#   profiles/<mode>-<chunker>.index.cpu.pprof  — pprof CPU profile (index phase)
+#   profiles/<mode>-<chunker>.index.mem.pprof  — pprof heap profile (index phase)
+#   <mode>-<chunker>.search.gtime
+#   profiles/<mode>-<chunker>.search.cpu.pprof
+#   profiles/<mode>-<chunker>.search.mem.pprof
+#
+# Analysis happens off-line with `pprof`, `benchstat`, and ad-hoc shell
+# tooling over records.jsonl.
+#
+# Exits non-zero on any sub-command failure. Idempotent: re-running on
+# the same day overwrites the day's records.
+
+set -euo pipefail
+
+# ── argument parsing ────────────────────────────────────────────────
+ALL_MODES=(bm25 semantic hybrid)
+ALL_CHUNKERS=(regex treesitter line)
+
+print_usage() {
+  cat >&2 <<'USAGE'
+usage: scripts/perf_collect.sh [flags] WORKLOAD
+
+WORKLOAD:  small | medium | large | giant | all
+
+Flags:
+  --modes=LIST       Comma-separated subset of {bm25,semantic,hybrid}. Default: all.
+  --chunkers=LIST    Comma-separated subset of {regex,treesitter,line}. Default: all.
+USAGE
+}
+
+usage_exit() { print_usage; exit 2; }
+
+# Validate a CSV "value,value,..." subset against an allowed-values array.
+# Returns 0 + prints the validated CSV (re-emitted unchanged) on success;
+# returns non-zero + prints an error on unknown value. Empty input is
+# treated as "use the default" and the caller substitutes the full set.
+validate_subset() {
+  local kind="$1" csv="$2"
+  shift 2
+  local allowed=("$@") v ok
+  IFS=',' read -ra got <<<"$csv"
+  for v in "${got[@]}"; do
+    ok=0
+    for a in "${allowed[@]}"; do
+      [[ "$v" == "$a" ]] && { ok=1; break; }
+    done
+    if [[ "$ok" -eq 0 ]]; then
+      echo "error: --$kind: unknown value '$v' (allowed: ${allowed[*]})" >&2
+      return 1
+    fi
+  done
+  printf '%s' "$csv"
+}
+
+MODES_FILTER=""
+CHUNKERS_FILTER=""
+POSITIONAL=()
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --modes=*)    MODES_FILTER="${1#--modes=}"; shift ;;
+    --modes)      [[ $# -ge 2 ]] || { echo "error: --modes requires a value" >&2; exit 2; }
+                  MODES_FILTER="$2"; shift 2 ;;
+    --chunkers=*) CHUNKERS_FILTER="${1#--chunkers=}"; shift ;;
+    --chunkers)   [[ $# -ge 2 ]] || { echo "error: --chunkers requires a value" >&2; exit 2; }
+                  CHUNKERS_FILTER="$2"; shift 2 ;;
+    -h|--help)    print_usage; exit 0 ;;
+    --)           shift; while [[ $# -gt 0 ]]; do POSITIONAL+=("$1"); shift; done ;;
+    -*)           echo "error: unknown flag '$1'" >&2; usage_exit ;;
+    *)            POSITIONAL+=("$1"); shift ;;
+  esac
+done
+
+if [[ ${#POSITIONAL[@]} -ne 1 ]]; then
+  usage_exit
+fi
+WORKLOAD="${POSITIONAL[0]}"
+
+if [[ -n "$MODES_FILTER" ]]; then
+  validate_subset modes "$MODES_FILTER" "${ALL_MODES[@]}" >/dev/null || exit 2
+  IFS=',' read -ra SELECTED_MODES <<<"$MODES_FILTER"
+else
+  SELECTED_MODES=("${ALL_MODES[@]}")
+fi
+if [[ -n "$CHUNKERS_FILTER" ]]; then
+  validate_subset chunkers "$CHUNKERS_FILTER" "${ALL_CHUNKERS[@]}" >/dev/null || exit 2
+  IFS=',' read -ra SELECTED_CHUNKERS <<<"$CHUNKERS_FILTER"
+else
+  SELECTED_CHUNKERS=("${ALL_CHUNKERS[@]}")
+fi
+
+# ── locate gtime / time ─────────────────────────────────────────────
+# OS-level peak RSS comes from gtime -v / time -v (GNU time). macOS
+# users need `brew install gnu-time` for gtime. Fall back to bash
+# `time` only if neither is present (warning emitted; the .gtime file
+# will be empty in that case but the run still completes).
+TIME_CMD=""
+if command -v gtime >/dev/null 2>&1; then
+  TIME_CMD="gtime"
+elif [[ -x /usr/bin/time ]] && /usr/bin/time -v true 2>/dev/null; then
+  TIME_CMD="/usr/bin/time"
+else
+  echo "warning: gtime / /usr/bin/time -v not available; OS-level RSS won't be captured" >&2
+  echo "  install with: brew install gnu-time (macOS) or apt-get install time (Linux)" >&2
+fi
+
+# ── workload resolution ─────────────────────────────────────────────
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+resolve_workload() {
+  case "$1" in
+    small)
+      echo "$REPO_ROOT"
+      ;;
+    medium)
+      echo "${WORKLOAD_MEDIUM:-$HOME/.cache/semble-bench}"
+      ;;
+    large)
+      echo "${WORKLOAD_LARGE:-$HOME/.cache/linux-v6.10}"
+      ;;
+    giant)
+      echo ""
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+# ── run one workload ────────────────────────────────────────────────
+run_workload() {
+  local wl="$1"
+  local wl_path
+  wl_path="$(resolve_workload "$wl")" || { echo "unknown workload: $wl" >&2; exit 2; }
+
+  if [[ "$wl" == "giant" ]]; then
+    echo "skip: giant workload is a Phase-1-defined stub — see docs/PERF.md Workloads" >&2
+    return 0
+  fi
+  if [[ -z "$wl_path" || ! -d "$wl_path" ]]; then
+    echo "error: $wl workload path '$wl_path' does not exist; see script header for bootstrap" >&2
+    exit 1
+  fi
+
+  local date_stamp
+  date_stamp="$(date +%Y-%m-%d)"
+  local out_dir="$REPO_ROOT/bench_out/$wl/$date_stamp"
+  mkdir -p "$out_dir/profiles"
+
+  # Build ken once with release flags so every invocation measures the
+  # same binary. -trimpath strips host paths; -ldflags='-s -w' strips
+  # symbol table + DWARF for the binary the user would actually ship.
+  local ken_bin="$out_dir/ken"
+  echo "build: $ken_bin (trimpath, -s -w; CGO_ENABLED=0)" >&2
+  CGO_ENABLED=0 go build -trimpath -ldflags='-s -w' -o "$ken_bin" "$REPO_ROOT/cmd/ken"
+
+  # Optional queries file for `perf search`. Falls back to a small
+  # built-in set if not provided. Phase-1 hardware can point this at a
+  # 1000-query corpus pulled from semble's annotations.
+  local queries_file="${PERF_QUERIES:-}"
+  local queries_owned=0
+  if [[ -z "$queries_file" ]]; then
+    queries_file="$out_dir/queries.txt"
+    queries_owned=1
+    cat >"$queries_file" <<'EOF'
+# Minimal built-in query set for sanity. Override with PERF_QUERIES=FILE.
+parse url
+build index
+http client
+function definition
+error handling
+async await
+class constructor
+return statement
+import package
+type alias
+EOF
+  fi
+
+  # ── meta.json header ──────────────────────────────────────────────
+  # modes_run / chunkers_run let downstream analysis distinguish a
+  # filtered run (--modes=bm25) from a full 3×3 matrix run. Critical
+  # for any aggregate comparison across dated dirs.
+  local started_at modes_json chunkers_json
+  started_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  modes_json="$(printf '"%s",' "${SELECTED_MODES[@]}")"
+  chunkers_json="$(printf '"%s",' "${SELECTED_CHUNKERS[@]}")"
+  {
+    echo "{"
+    echo "  \"workload\": \"$wl\","
+    echo "  \"workload_path\": \"$wl_path\","
+    echo "  \"started_at\": \"$started_at\","
+    echo "  \"uname\": \"$(uname -a)\","
+    echo "  \"go_version\": \"$(go version)\","
+    echo "  \"ken_commit\": \"$(git -C "$REPO_ROOT" rev-parse HEAD)\","
+    echo "  \"build_flags\": \"CGO_ENABLED=0 go build -trimpath -ldflags='-s -w'\","
+    echo "  \"modes_run\": [${modes_json%,}],"
+    echo "  \"chunkers_run\": [${chunkers_json%,}]"
+    echo "}"
+  } >"$out_dir/meta.json"
+
+  # Truncate records.jsonl so re-running today doesn't accumulate.
+  : >"$out_dir/records.jsonl"
+
+  # ── (mode × chunker) cross-product ────────────────────────────────
+  # Use the globally-filtered SELECTED_MODES / SELECTED_CHUNKERS so a
+  # --modes=bm25 --chunkers=regex invocation runs only the 1×1 = 2
+  # invocations instead of 3×3 = 18.
+  local mode chunker tag
+  for mode in "${SELECTED_MODES[@]}"; do
+    for chunker in "${SELECTED_CHUNKERS[@]}"; do
+      tag="$mode-$chunker"
+      echo "  $wl: $tag" >&2
+
+      # `perf index` — one record + cpu + mem profile.
+      local cpu_index="$out_dir/profiles/$tag.index.cpu.pprof"
+      local mem_index="$out_dir/profiles/$tag.index.mem.pprof"
+      local gtime_index="$out_dir/$tag.index.gtime"
+      if [[ -n "$TIME_CMD" ]]; then
+        "$TIME_CMD" -v -o "$gtime_index" \
+          "$ken_bin" perf index "$wl_path" \
+          --mode "$mode" --chunker "$chunker" \
+          --cpuprofile "$cpu_index" --memprofile "$mem_index" \
+          >>"$out_dir/records.jsonl"
+      else
+        "$ken_bin" perf index "$wl_path" \
+          --mode "$mode" --chunker "$chunker" \
+          --cpuprofile "$cpu_index" --memprofile "$mem_index" \
+          >>"$out_dir/records.jsonl"
+      fi
+
+      # `perf search` — one record + cpu + mem profile.
+      local cpu_search="$out_dir/profiles/$tag.search.cpu.pprof"
+      local mem_search="$out_dir/profiles/$tag.search.mem.pprof"
+      local gtime_search="$out_dir/$tag.search.gtime"
+      if [[ -n "$TIME_CMD" ]]; then
+        "$TIME_CMD" -v -o "$gtime_search" \
+          "$ken_bin" perf search "$wl_path" \
+          --mode "$mode" --chunker "$chunker" \
+          --queries "$queries_file" --n 1000 -k 10 \
+          --cpuprofile "$cpu_search" --memprofile "$mem_search" \
+          >>"$out_dir/records.jsonl"
+      else
+        "$ken_bin" perf search "$wl_path" \
+          --mode "$mode" --chunker "$chunker" \
+          --queries "$queries_file" --n 1000 -k 10 \
+          --cpuprofile "$cpu_search" --memprofile "$mem_search" \
+          >>"$out_dir/records.jsonl"
+      fi
+    done
+  done
+
+  # ── meta.json footer (rewrite with ended_at) ──────────────────────
+  local ended_at
+  ended_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  python3 - "$out_dir/meta.json" "$ended_at" <<'PY' || true
+import json, sys
+path, ended = sys.argv[1], sys.argv[2]
+with open(path) as f:
+    d = json.load(f)
+d["ended_at"] = ended
+with open(path, "w") as f:
+    json.dump(d, f, indent=2)
+PY
+
+  # Clean up the built-in queries file if we created it; preserve the
+  # user's own file if PERF_QUERIES pointed somewhere.
+  if [[ "$queries_owned" -eq 1 ]]; then
+    rm -f "$queries_file"
+  fi
+
+  echo "done: $out_dir" >&2
+}
+
+case "$WORKLOAD" in
+  small|medium|large|giant)
+    run_workload "$WORKLOAD"
+    ;;
+  all)
+    # --modes / --chunkers filters apply uniformly to each workload in
+    # the cascade — handy for a smoke pass like
+    # `scripts/perf_collect.sh all --modes=bm25 --chunkers=regex`.
+    run_workload small
+    run_workload medium
+    run_workload large
+    ;;
+  *)
+    echo "error: unknown workload '$WORKLOAD'" >&2
+    usage_exit
+    ;;
+esac


### PR DESCRIPTION
## Summary

- **Promotes ADR-025** (perf-campaign Phase 1 investigation outcome — hotspot identification across small + medium workloads) from [outputs/](outputs/adr-025-perf-investigation-outcome.md) into [docs/DECISIONS.md](docs/DECISIONS.md), with Status flipped to Accepted, summary-table entry added, all 5 cross-references verified to resolve, and the `<TODO: SHA>` placeholder filled in with [`120fc06`](https://github.com/townsendmerino/ken/commit/120fc06) (the cAST degenerate-span fix).
- **Lands the Phase 0 measurement harness on main** — every file that previously only lived on `perf-investigation`: [`internal/perf/`](internal/perf/) helper package, [`cmd/ken/perf.go`](cmd/ken/perf.go) subcommand + main.go wiring, the 5 remaining bench files (embed, chunk regex+treesitter, search rerank, repo walk), and [`scripts/perf_collect.sh`](scripts/perf_collect.sh) (with the `--modes`/`--chunkers` filter flags). Closes the unstable state where main had v0.8.4's ADR-026 calibration claims but not the harness that produced them.
- **Adds [`docs/PERF.md`](docs/PERF.md)** to main: methodology stub (commit 1) + Phase 1 Empirical findings (commit 3) + the corrected workload table (~19 → 63 repos / ~80k files / ~378k chunks for medium). Headline numbers section deliberately stays empty per the acceptance threshold (median-of-N + second-machine confirm before publication).

## Test plan

- [x] `gofmt -l cmd internal` clean
- [x] `go vet ./...` clean
- [x] `go build ./...` ok (incl. `ken perf` subcommand wiring)
- [x] `go test ./...` green (benchmarks don't run under default `go test`; `embed_bench_test.go`'s `b.Skip()` on missing `testdata/model/` works)
- [x] All 5 ADR-025 cross-references (ADR-010, ADR-011, ADR-016, ADR-023, ADR-024) resolve as anchors
- [x] All 10 harness files (excluding `docs/PERF.md`) byte-identical to `perf-investigation` HEAD
- [x] `docs/PERF.md` differs from `perf-investigation` only in the deliberate commit-3 edits

## Commit shape (7 commits)

| # | SHA | summary |
|---|---|---|
| 1 | [`17b4810`](https://github.com/townsendmerino/ken/commit/17b4810) | `docs/PERF.md` methodology stub |
| 2 | [`af7b708`](https://github.com/townsendmerino/ken/commit/af7b708) | ADR-025 promoted to `docs/DECISIONS.md` + summary table |
| 3 | [`ee98270`](https://github.com/townsendmerino/ken/commit/ee98270) | PERF.md Empirical findings + workload-table reconciliation |
| 4 | [`994e7df`](https://github.com/townsendmerino/ken/commit/994e7df) | `internal/perf/` measurement helpers |
| 5 | [`952c5f4`](https://github.com/townsendmerino/ken/commit/952c5f4) | `cmd/ken/perf.go` (index/search/watch) + main.go wiring |
| 6 | [`c09e7ff`](https://github.com/townsendmerino/ken/commit/c09e7ff) | 5 remaining bench files (embed, chunk×2, search rerank, repo walk) |
| 7 | [`ead6e07`](https://github.com/townsendmerino/ken/commit/ead6e07) | `scripts/perf_collect.sh` with `--modes`/`--chunkers` filters |

## Notes

- **`internal/ann/ann_bench_test.go`** + **`internal/bm25/bm25_bench_test.go`** are already on main from v0.8.4 (PR #22, `fa5a43d`); verified byte-identical to `perf-investigation`'s versions and skipped per briefing.
- **Approach taken:** pure cherry-pick for `internal/perf/` (commit 4); `git checkout perf-investigation -- <files>` for commits 5-7 (cmd/ken/perf.go's 3-commit chain + 5 bench files + scripts/perf_collect.sh). Same end state as full cherry-pick chain, avoids replaying intermediate PERF.md edits that would all conflict with commit 1's final-state PERF.md.
- **ADR-025 source file** at `outputs/adr-025-perf-investigation-outcome.md` is unchanged — that's the canonical draft, this file is now the authoritative promoted version per the standard pattern.
- **`outputs/treesitter-port-considerations.md`** referenced by ADR-025 is unchanged per briefing.
- **No code-behavior changes.** v0.8.4 already shipped the heap refactor; v0.8.5+ ships the BM25 tokenizer alloc reduction (next ADR). This PR is docs + harness landing only.

Generated with [Claude Code](https://claude.com/claude-code)