### PR TITLE
perf(v0.8.5): BM25 tokenizer allocation reduction ([]rune → []byte + sync.Pool)

### DIFF
--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -32,6 +32,7 @@ ADR statuses: **Proposed** (documenting design alternatives; no implementation d
 | [ADR-024](#adr-024-pre-built-embedded-indices-for-mcprun-v083) | Pre-built embedded indices for `mcp.Run` (v0.8.3) | Accepted |
 | [ADR-025](#adr-025-perf-campaign-phase-1-investigation-outcome--hotspot-identification-across-small--medium-workloads) | Perf-campaign Phase 1 investigation outcome — hotspot identification across small + medium workloads | Accepted |
 | [ADR-026](#adr-026-paired-heap-refactor-for-annflatquery--bm25indextopk-v084) | Paired heap refactor for `ann.Flat.Query` + `bm25.Index.TopK` via shared `internal/topk` (v0.8.4) | Accepted |
+| [ADR-027](#adr-027-bm25-tokenizer-allocation-reduction--rune--byte--syncpool-scratch--lowercase-fast-path-v085) | BM25 tokenizer allocation reduction (`[]rune` → `[]byte` + `sync.Pool` scratch + lowercase fast-path) (v0.8.5) | Accepted |
 
 ---
 
@@ -1574,3 +1575,134 @@ Replace sort-then-slice with min-heap-of-size-K in `ann.Flat.Query` and `bm25.In
 - **Two-commit PR shape.** Commit 1 lands `internal/topk` + tests + micro-benchmark; commit 2 lands the two refactors + this ADR-026. Reviewers see the new utility in isolation before reading the integrations.
 
 - **Future perf work informed.** The remaining ADR-025 hotspots (BM25 tokenizer allocs at ~45% of indexing allocs, embed `weightedMeanPoolSafe` accumulator) will ship in subsequent rolling point releases (v0.8.5+) as the analysis from this work feeds back into the prioritization. Specifically, with search latency cut as documented above, the embed inference cost becomes a proportionally larger fraction of cold-start time on the giant-corpus workload that the planning Claude's Phase 1 medium re-run will benchmark next.
+
+---
+
+## ADR-027: BM25 tokenizer allocation reduction — `[]rune` → `[]byte` + `sync.Pool` scratch + lowercase fast-path (v0.8.5)
+
+**Status:** Accepted
+
+**Date:** 2026-05-26
+
+**Issue:** TBD (open a townsendmerino/ken issue for the v0.8.5 tokenizer-allocs work + cross-link here on merge).
+
+**Extends:** [ADR-025](#adr-025-perf-campaign-phase-1-investigation-outcome--hotspot-identification-across-small--medium-workloads) (perf-investigation outcome that ranked BM25 tokenizer alloc reduction as Ship-tier #3), [ADR-008](#adr-008-bm25-tokenizer--verbatim-port-of-sembles-tokenspy-snake-case-compound-preservation) (verbatim-parity contract — this refactor explicitly affirms token-set parity is preserved).
+
+### Context
+
+[ADR-025](#adr-025-perf-campaign-phase-1-investigation-outcome--hotspot-identification-across-small--medium-workloads)'s medium-scale (semble bench corpus, 378,524 chunks) alloc_space pprof attributed **~45% of bm25-regex indexing allocations to the tokenizer**:
+
+```
+bm25.Tokenize.func1            5.7 GB  (29.6%)
+bm25.camelSplit                2.6 GB  (13.5%)
+bm25.Tokenize.func1-range1     0.37 GB (1.9%)
+─────────────────────────────────────────────
+Tokenizer subtotal            ~8.7 GB  (~45%)
+```
+
+Per-chunk tokenizer allocation grew from 35 KB (small workload, 1,560 chunks) to 53 KB (medium, 378k chunks) — not constant overhead; the cost grew with scale. GC dominated indexing CPU at scale (~50% per ADR-025), so the wall-time win from reducing tokenizer allocs is larger than the alloc-bytes number alone suggests — every byte not allocated is a byte the GC doesn't have to scan.
+
+The hotspot's structural source: the tokenizer iterated text as `[]rune` (4 bytes per ASCII char) and called `strings.ToLower(string(run))` twice per token (once for the compound, once per camelSplit part), each conversion allocating. ASCII-only design — `isIdentStart` / `isIdentCont` reject non-ASCII bytes — means the `[]rune` decoding was paying UTF-8 overhead it didn't need.
+
+[ADR-008](#adr-008-bm25-tokenizer--verbatim-port-of-sembles-tokenspy-snake-case-compound-preservation) makes the load-bearing constraint explicit: `Tokenize` is a verbatim port of `semble/tokens.py`, and any change that affects its token output violates the parity contract. The refactor's North Star is therefore "cut allocations without changing output bytes."
+
+### Decision
+
+Refactor `internal/bm25/tokenize.go` to scan input bytes directly (instead of decoding runes) and to share a `sync.Pool`-backed scratch buffer across calls for lowercase conversion. Public API unchanged: `Tokenize(text string) []string` and the documented identifier-extraction + split semantics are preserved byte-for-byte.
+
+**Three allocation levers:**
+
+1. **Byte-level scan replaces rune decoding.** ASCII identifier bytes (0x30-0x39, 0x41-0x5A, 0x5F, 0x61-0x7A) are all < 0x80; UTF-8 multi-byte sequences use only 0x80-0xFF bytes. The two ranges don't overlap, so a non-ASCII byte cannot false-positive as an identifier-start byte and correctly terminates any in-progress run. Byte-iteration is structurally faster than `for _, r := range text`'s UTF-8 decoder and removes the `[]rune` allocation entirely.
+
+2. **`sync.Pool` scratch buffer for lowercase conversion.** Each `Tokenize` call gets one pooled `[]byte` (initial cap 256, grows for rare long identifiers); the buffer is reused for every `lowerString` slow-path conversion within the call and returned to the pool on defer. Eliminates per-token allocation for the lowercase output buffer.
+
+3. **Lowercase fast-path.** `lowerString` scans for any uppercase ASCII byte first; if none, returns the input string unchanged — zero allocation, the same string header pointing at the same underlying bytes. Real-source identifiers (variable names, function names that are already lowercase or whose parts are after camelSplit) hit this path constantly. Slow path is exactly one allocation (`string(*scratch)` after the per-byte ToLower copy) — half of the prior pattern's two allocations (`string(rune-slice)` then `strings.ToLower(string)`).
+
+**Implementation supporting details:**
+
+- `isIdentStartByte` / `isIdentContByte` / `isUpperByte` / `isLowerByte` / `isDigitByte` replace the rune-typed predicates; trivially zero-allocation.
+- `slices.Contains(rs, '_')` replaced by `strings.IndexByte(run, '_') >= 0` — single byte scan, no slice header overhead.
+- `strings.SplitSeq(compound, "_")` iterator replaced by hand-rolled snake-split over the SOURCE run (not the lowercased compound) so each part takes the lowercase fast-path independently when already lowercase.
+- `camelSplitBytes` is a verbatim algorithmic port of the old `camelSplit` to byte offsets — same ordered-alternation regex semantics from semble's `_CAMEL_RE`. Lowercase-only and digit-only matches emit source views via the fast-path; uppercase-containing matches go through `lowerString` with the shared scratch.
+
+### Alternatives considered
+
+- **Change `Tokenize` to return `[][]byte`.** Rejected for API-invasiveness and [ADR-008](#adr-008-bm25-tokenizer--verbatim-port-of-sembles-tokenspy-snake-case-compound-preservation) scope. The function-level contract is byte-equality of output strings, not return-type identity. The return-type change would ripple into `bm25.Build`'s map-insertion path, query-side tokenization, and external consumers via the `Tokenize` symbol — invasive blast radius for a marginal additional alloc reduction. Documented in the v0.8.5 briefing as deferred.
+
+- **Optimize `bm25.Build`'s postings-map lookup with the `m[string(b)]` compiler-optimized pattern.** Considered for v0.8.5; rejected to keep scope tight. The win depends on `Tokenize` returning `[][]byte` (alternative above, also rejected) AND a more complex Build refactor. Flagged as v0.8.6+ candidate after we see whether post-v0.8.5 GC pressure still warrants chasing it. ADR-025 ranked `bm25.Build` at 37.6% of indexing allocations — the larger absolute target — but the path to reduce it is more invasive than the tokenizer rewrite.
+
+- **Adopt a third-party tokenizer** (e.g., `bluge`'s analyzer chain, or import the Python tokenizer via a CGO bridge). Rejected for two reasons: (a) [ADR-008](#adr-008-bm25-tokenizer--verbatim-port-of-sembles-tokenspy-snake-case-compound-preservation)'s verbatim-parity contract with semble's `tokens.py` would be at the mercy of an external library's choices, and (b) [ADR-001](#adr-001-pure-go-no-cgo) forbids CGO regardless. The byte-level refactor keeps the existing verbatim port intact.
+
+- **Pool the `Tokenize` result `[]string` slice in addition to the scratch buffer.** Considered. Started without it; allocation profiles after the refactor show the result-slice growth is not a remaining hotspot (the scratch-pool + fast-path already eliminate the per-token output-buffer allocation; the result slice itself is one growing append). Adding result-slice pooling would complicate the API contract (callers would need to release the slice, or the pool would have to copy) for diminishing return. Documented for v0.8.6+ if a future profile shows otherwise.
+
+- **Skip the lowercase fast-path; always lowercase via scratch.** Marginally simpler code but loses the zero-allocation common case. Real-source identifiers are predominantly already lowercase (variable names, after-camelSplit parts); the fast-path is the load-bearing alloc-reduction lever, not just an optimization. Kept.
+
+- **Pre-size the `parts []string` slice in `camelSplitBytes` and the `out []string` slice in `Tokenize`.** Considered. Both are small slices (typical identifier produces 2-4 parts; typical chunk produces tens of tokens). The growth-from-empty pattern's amortized cost is bounded, and pre-sizing would require an upfront scan to count. Skipped on cost/benefit — pre-sizing would help a marginal alloc count but adds a scan pass. Revisit if profile shows otherwise.
+
+### Consequences
+
+**Measured impact** (Apple M1 Pro / Go 1.26.3 / darwin/arm64 / `CGO_ENABLED=0 -trimpath -ldflags='-s -w'`):
+
+- **`Tokenize` micro-benchmark** (`go test -bench BenchmarkTokenize -benchmem -count=10`, before = main HEAD with rune-based code, after = this commit):
+
+  ```
+              │  rune-based       │  byte-based                    │
+              │   sec/op          │   sec/op       vs base         │
+  Tokenize    │ 530.8µs ± 3%      │ 267.8µs ± 2%   −49.5% (p=0.000) │
+
+              │  B/s              │  B/s           vs base          │
+  Tokenize    │ 47.36 MiB/s ± 3%  │ 93.87 MiB/s ± 2%  +98.2% (p=0.000) │
+
+              │  B/op             │  B/op          vs base          │
+  Tokenize    │ 398.7 KiB ± 0%    │ 318.9 KiB ± 0%  −20.0% (p=0.000) │
+
+              │  allocs/op        │  allocs/op     vs base          │
+  Tokenize    │ 13,600 ± 0%       │ 5,613 ± 0%     −58.7% (p=0.000) │
+  ```
+
+  The `BenchmarkScore/N100` and `/N1000` benchmarks (which exercise `bm25.Index.TopK`) show no movement on this commit, as expected — those benchmarks build the corpus + index outside the timer, so they don't measure `Tokenize` in the hot loop.
+
+  The B/op reduction (−20%) is below the briefing's −50-80% projection range. The shortfall is because the lowercase fast-path's zero-allocation case only fires when an identifier is entirely lowercase; real-source corpora have many mixed-case identifiers (camelCase, PascalCase) that take the slow path. The allocs/op reduction (−58.7%) is the more representative win because it captures every avoided allocation regardless of byte size. Briefing surfaced this as a flag-if-below; documented here as the actual measured outcome.
+
+- **End-to-end medium-corpus re-measurement** (`scripts/perf_collect.sh medium --modes=bm25,hybrid --chunkers=regex`, 378,524 chunks):
+
+  | combo | metric | rune-based | byte-based | Δ |
+  |---|---|---|---|---|
+  | bm25-regex INDEX | wall time | 59.8s | **40.1s** | **−32.9%** |
+  | bm25-regex INDEX | objects allocated | 301.9M | **133.6M** | **−55.7%** |
+  | bm25-regex INDEX | bytes allocated | 18.80 GB | 16.86 GB | −10.3% |
+  | bm25-regex INDEX | heap inuse | 6.41 GB | 5.96 GB | −7.0% |
+  | bm25-regex SEARCH | p50 | 1.78 ms | 1.76 ms | ≈ noise |
+  | hybrid-regex INDEX | wall time | 192.8s | **166.8s** | **−13.5%** |
+  | hybrid-regex INDEX | heap inuse | 9.13 GB | **5.71 GB** | **−37.5%** |
+  | hybrid-regex INDEX | objects allocated | 820.3M | 652.0M | −20.5% |
+  | hybrid-regex SEARCH | p50 | 117.9 ms | 124.1 ms | +5% (within noise) |
+
+  The bm25 indexing wall-time reduction (−32.9%) hits the upper end of the briefing's −20-30% projection. The cause is the GC-time reduction: ADR-025 measured GC at ~50% of medium-scale indexing CPU; the tokenizer's −55.7% object-count drop translates roughly proportionally into GC pressure drop. The hybrid indexing wall-time reduction (−13.5%) is smaller because embedding is the dominant cost in hybrid mode and is unaffected by this refactor — but the bm25 portion of hybrid indexing still benefits, so the net is non-trivial. **Search latency is unchanged within noise** in both modes — sanity check that the refactor only touched the indexing tokenizer.
+
+  Heap inuse drop on hybrid (−37.5%) is the most-surprising win: the steady-state hybrid index retains less working memory because lowercase tokens now share storage with the chunk text (the `lowerString` fast-path returns the source string view) rather than being independent copies. The chunk text is retained by the index anyway, so the net working set shrinks.
+
+- **NDCG@10 safety check** (semble bench corpus, 63 repos / 1251 tasks, all 3 modes, `--chunker regex` both sides):
+
+  | mode | rune-based NDCG@10 | byte-based NDCG@10 | Δ |
+  |---|---|---|---|
+  | bm25 | 0.6237 | 0.6237 | **0.0000** (exact) |
+  | semantic | 0.6469 | 0.6469 | **0.0000** (exact) |
+  | hybrid | 0.8418 | 0.8418 | **0.0000** (exact) |
+
+  Exact match in all three modes is the strongest possible confirmation of token-set parity: same tokens in → same scores → same K results → same ranking → identical NDCG@10. The v0.8.5 briefing called this an exact-match requirement (the ±0.005 escape hatch in `docs/PERF.md`'s acceptance threshold is reserved for intentional algorithmic changes; this refactor is "same tokens, less allocation" so any non-zero delta would indicate a bug). NDCG-bench wall times also dropped substantially (bm25 9.1 → 5.7s, semantic 32.4 → 23.3s, hybrid 81.9 → 50.4s — the per-repo index builds in the NDCG harness pay the same tokenizer-alloc-reduction win).
+
+- **Token-set parity test extension.** `internal/bm25/tokenize_test.go` grew three new test functions ([commit 1/2 of this PR](https://github.com/townsendmerino/ken/commit/6042be5)):
+  - `TestTokenize_AdversarialParity` (16 sub-cases): whitespace-only / pure-punctuation, camelCase + acronym + digit mixes, snake leading/trailing/multiple underscores, digit-start runs, non-ASCII input (the load-bearing UTF-8 byte-vs-rune-equivalence cases), a real Go source snippet, and a multi-identifier stress input. All expected outputs hand-traced against the pre-refactor rune-based impl and verified on main HEAD before the refactor landed.
+  - `TestTokenize_StablePoolReuse`: 100 iterations of three representative inputs, requires byte-identical output on every iteration. Catches scratch-buffer-pool corruption (one call leaking state into the next).
+  - `TestTokenize_LongInputNoPanic`: deterministic 4 KiB realistic input + 10 pool-stability re-runs. Catches pool corruption at scale that the StablePoolReuse stress might miss with small inputs.
+
+  All adversarial cases + the existing 28-case `TestTokenize_IdentifierSplitting` suite pass byte-identically on the byte-based impl — that's what makes the NDCG exact-match result mechanically guaranteed.
+
+- **Allocations per call go DOWN, not up** (different from ADR-026's +3 trade). The `sync.Pool` scratch buffer eliminates the per-token output-buffer allocation; the lowercase fast-path eliminates allocations for the common already-lowercase case; the byte-level scan eliminates the rune-slice growth. Both alloc count AND alloc bytes drop. This is the opposite tradeoff from ADR-026's heap refactor (which traded +3 allocs for −99% bytes); here both metrics improve together.
+
+- **No public API changes.** `Tokenize(text string) []string` signature unchanged. The `[]string` return type stays per [ADR-008](#adr-008-bm25-tokenizer--verbatim-port-of-sembles-tokenspy-snake-case-compound-preservation)'s function-level byte-equality contract.
+
+- **No new third-party dependencies.** Refactor uses only standard library (`strings`, `sync`). Drops two prior dependencies inside the file (`slices`, `strings.SplitSeq`/`strings.ToLower`/`strings.IndexByte`) in favor of the byte-direct equivalents.
+
+- **Future perf work informed.** Post-v0.8.5, the remaining ADR-025 hotspots are: `bm25.Build`'s 37.6% indexing-alloc share (potentially addressable via `m[string(b)]` lookup pattern — deferred to v0.8.6+ pending a re-measurement that shows it's still worth the API churn), and the embed pipeline (`weightedMeanPoolSafe` accumulator at 23% of small hybrid CPU — gated on a pure-Go-no-cgo SIMD pattern). GC pressure should drop substantially with this refactor in tree, which will shift the relative shares.

--- a/internal/bm25/tokenize.go
+++ b/internal/bm25/tokenize.go
@@ -23,13 +23,27 @@
 //     compound preservation: `validate_user` tokenizes to `["validate_user",
 //     "validate", "user"]` (compound first), not `["validate", "user"]`.
 //     CamelCase splitting matches the `_CAMEL_RE` regex's ordered
-//     alternation. See ADR-008 for why verbatim parity is the contract.
+//     alternation. See ADR-008 for why verbatim parity is the contract,
+//     and ADR-027 for the v0.8.5 alloc-reduction refactor that
+//     preserves byte-equality of Tokenize output.
 package bm25
 
 import (
-	"slices"
 	"strings"
+	"sync"
 )
+
+// tokenizerScratch pools per-call scratch byte buffers used by lowerString
+// for lowercase conversion. Starting cap of 256 bytes covers the typical
+// identifier-length distribution; the buffer grows automatically for rare
+// long identifiers and Put resets length but keeps cap. Sharing across
+// goroutines is fine — sync.Pool is the canonical Go idiom for this.
+var tokenizerScratch = sync.Pool{
+	New: func() any {
+		b := make([]byte, 0, 256)
+		return &b
+	},
+}
 
 // Tokenize is a verbatim port of /tmp/semble/src/semble/tokens.py. It
 // extracts identifier-like ASCII runs matching `[a-zA-Z_][a-zA-Z0-9_]*`
@@ -44,38 +58,82 @@ import (
 // has the rare `validate_user` compound term — otherwise the score
 // splits across two common parts (`validate`, `user`) and BM25 IDF
 // distributes weight thinly. See docs/BENCH.md for the measured impact
-// on semble's NDCG benchmark.
+// on semble's NDCG benchmark, and ADR-008 for the parity contract.
 //
 // Behavior to keep in lock-step with semble:
-//   - Run extraction follows `_TOKEN_RE` exactly: first rune must be
+//   - Run extraction follows `_TOKEN_RE` exactly: first byte must be
 //     `[a-zA-Z_]` (ASCII letter or underscore — digits and non-ASCII
-//     letters never start a run); continuation may also include digits.
+//     bytes never start a run); continuation may also include digits.
 //     Standalone digit-only runs are therefore dropped, matching Python.
 //   - Sub-tokenization follows `split_identifier`: if `_` is in the run,
 //     split on `_` (drop empties) — no camel recursion inside the parts.
 //     Otherwise camelCase-split via the same `_CAMEL_RE` regex, modeled
-//     by camelSplit below.
+//     by camelSplitBytes below.
 //   - Output order is `[compound, *parts]` (compound first), matching
 //     semble.split_identifier exactly.
+//
+// Implementation note (v0.8.5 / ADR-027): scans bytes directly rather
+// than decoding UTF-8 runes. The byte-level scan produces output
+// byte-identical to a rune-based scan on non-ASCII input because UTF-8
+// multi-byte sequences use only 0x80-0xFF bytes — never in the ASCII
+// identifier ranges (0x30-0x39, 0x41-0x5A, 0x5F, 0x61-0x7A) — so a
+// non-ASCII byte correctly terminates any run-in-progress and cannot
+// false-positive as an identifier start. TestTokenize_AdversarialParity
+// pins this with explicit non-ASCII cases.
 func Tokenize(text string) []string {
+	bufPtr := tokenizerScratch.Get().(*[]byte)
+	defer func() {
+		*bufPtr = (*bufPtr)[:0]
+		tokenizerScratch.Put(bufPtr)
+	}()
+
 	var out []string
-	var run []rune
-	inRun := false
-	flush := func() {
-		if len(run) == 0 {
-			return
-		}
-		compound := strings.ToLower(string(run))
-		var parts []string
-		if containsUnderscore(run) {
-			// snake_case: split on '_' (drop empties), no camel recursion.
-			for p := range strings.SplitSeq(compound, "_") {
-				if p != "" {
-					parts = append(parts, p)
-				}
+	runStart := -1
+	n := len(text)
+
+	for i := 0; i < n; i++ {
+		c := text[i]
+		if runStart < 0 {
+			if isIdentStartByte(c) {
+				runStart = i
 			}
-		} else {
-			parts = camelSplit(run)
+			continue
+		}
+		if isIdentContByte(c) {
+			continue
+		}
+		// Non-identifier byte ends the current run at i (exclusive).
+		out = emitRun(text[runStart:i], bufPtr, out)
+		runStart = -1
+	}
+	if runStart >= 0 {
+		out = emitRun(text[runStart:], bufPtr, out)
+	}
+	return out
+}
+
+// emitRun appends the [compound, *parts] decomposition of one identifier
+// run to out. Dispatches to the snake- or camel-split path based on
+// whether the run contains an underscore byte. Single-part runs emit
+// only the compound.
+func emitRun(run string, scratch *[]byte, out []string) []string {
+	compound := lowerString(run, scratch)
+
+	if strings.IndexByte(run, '_') >= 0 {
+		// Snake split: iterate the run looking for '_' boundaries.
+		// Operating on the SOURCE run (not the lowercased compound)
+		// lets each part take the lowerString fast-path when it's
+		// already lowercase. Empty parts (consecutive '_' or leading/
+		// trailing '_') are filtered, matching semble's `if p`.
+		var parts []string
+		start := 0
+		for i := 0; i <= len(run); i++ {
+			if i == len(run) || run[i] == '_' {
+				if i > start {
+					parts = append(parts, lowerString(run[start:i], scratch))
+				}
+				start = i + 1
+			}
 		}
 		if len(parts) >= 2 {
 			out = append(out, compound)
@@ -83,102 +141,130 @@ func Tokenize(text string) []string {
 		} else {
 			out = append(out, compound)
 		}
-		run = run[:0]
-		inRun = false
+		return out
 	}
-	for _, r := range text {
-		if !inRun {
-			if isIdentStart(r) {
-				run = append(run, r)
-				inRun = true
-			}
-			continue
-		}
-		if isIdentCont(r) {
-			run = append(run, r)
-		} else {
-			flush()
-		}
+
+	// camelCase split: operates on byte offsets into run.
+	parts := camelSplitBytes(run, scratch)
+	if len(parts) >= 2 {
+		out = append(out, compound)
+		out = append(out, parts...)
+	} else {
+		out = append(out, compound)
 	}
-	flush()
 	return out
 }
 
-// isIdentStart matches Python regex `[a-zA-Z_]` — ASCII only. A digit or
-// any non-ASCII letter cannot start an identifier run.
-func isIdentStart(r rune) bool {
-	return (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || r == '_'
+// lowerString returns the lowercase of s. Two paths:
+//
+//   - Fast: if s contains no uppercase ASCII byte, returns s unchanged.
+//     Zero allocation; the returned string is the same string header
+//     pointing at the same underlying bytes. The common case for
+//     real-source identifiers (variable names, function names) hits
+//     this path.
+//   - Slow: copies s into scratch with uppercase bytes lowered, then
+//     returns `string(scratch)`. Exactly one allocation regardless of
+//     input length (vs the pre-refactor pattern's two: rune→string +
+//     strings.ToLower).
+//
+// scratch is a pooled byte buffer; emitRun's caller (Tokenize) owns it
+// and resets length on Put. lowerString resets it to zero length before
+// each use.
+func lowerString(s string, scratch *[]byte) string {
+	for i := 0; i < len(s); i++ {
+		if s[i] >= 'A' && s[i] <= 'Z' {
+			// Has at least one uppercase byte; take the slow path.
+			*scratch = (*scratch)[:0]
+			for j := 0; j < len(s); j++ {
+				c := s[j]
+				if c >= 'A' && c <= 'Z' {
+					c += 'a' - 'A'
+				}
+				*scratch = append(*scratch, c)
+			}
+			return string(*scratch)
+		}
+	}
+	return s
 }
 
-// isIdentCont matches Python regex `[a-zA-Z0-9_]` — ASCII only.
-func isIdentCont(r rune) bool {
-	return isIdentStart(r) || (r >= '0' && r <= '9')
+// isIdentStartByte matches Python regex `[a-zA-Z_]` — ASCII only. A
+// digit or any non-ASCII byte (≥ 0x80) cannot start an identifier run.
+func isIdentStartByte(c byte) bool {
+	return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || c == '_'
 }
 
-func isUpper(r rune) bool { return r >= 'A' && r <= 'Z' }
-func isLower(r rune) bool { return r >= 'a' && r <= 'z' }
-func isDigit(r rune) bool { return r >= '0' && r <= '9' }
-
-func containsUnderscore(rs []rune) bool {
-	return slices.Contains(rs, '_')
+// isIdentContByte matches Python regex `[a-zA-Z0-9_]` — ASCII only.
+func isIdentContByte(c byte) bool {
+	return isIdentStartByte(c) || (c >= '0' && c <= '9')
 }
 
-// camelSplit implements semble's `_CAMEL_RE` under Python `re.findall` on a
-// run that contains only `[a-zA-Z0-9]` (no underscores). Returns the
-// lowercased sub-tokens in match order.
+func isUpperByte(c byte) bool { return c >= 'A' && c <= 'Z' }
+func isLowerByte(c byte) bool { return c >= 'a' && c <= 'z' }
+func isDigitByte(c byte) bool { return c >= '0' && c <= '9' }
+
+// camelSplitBytes is the byte-level port of the v0.8.4-and-earlier
+// camelSplit. Operates on a run that contains only [a-zA-Z0-9] (no
+// underscores) and returns lowercased sub-tokens in match order. Uses
+// scratch for per-part lowercasing via lowerString; runs of pure
+// lowercase or digits hit the fast path and are returned as views into
+// the source.
+//
+// Algorithm (verbatim semantics from the []rune version):
 //
 //	_CAMEL_RE = r"[A-Z]+(?=[A-Z][a-z])|[A-Z]?[a-z]+|[A-Z]+|[0-9]+"
 //
-// Ordered alternation: at each position try the alternatives left-to-right.
-// Greedy `[A-Z]+(?=[A-Z][a-z])` consumes the largest upper prefix such that
-// the next char is upper AND the one after that is lower — equivalent to:
-// for an upper run rs[i:j], if rs[j] is lowercase and the run has ≥2
-// uppers, consume rs[i:j-1] and let rs[j-1] start the next match. This is
-// what splits "HTTPResponse" into "HTTP" + "Response" and "XMLParser" into
-// "XML" + "Parser".
-func camelSplit(rs []rune) []string {
+// Ordered alternation: at each position try the alternatives left-to-
+// right. Greedy `[A-Z]+(?=[A-Z][a-z])` consumes the largest upper
+// prefix such that the next char is upper AND the one after that is
+// lower — equivalent to: for an upper run run[i:j], if run[j] is
+// lowercase and the run has ≥2 uppers, consume run[i:j-1] and let
+// run[j-1] start the next match. This is what splits "HTTPResponse"
+// into "HTTP" + "Response" and "XMLParser" into "XML" + "Parser".
+func camelSplitBytes(run string, scratch *[]byte) []string {
 	var parts []string
-	n := len(rs)
+	n := len(run)
 	for i := 0; i < n; {
-		r := rs[i]
+		c := run[i]
 		switch {
-		case isUpper(r):
+		case isUpperByte(c):
 			j := i
-			for j < n && isUpper(rs[j]) {
+			for j < n && isUpperByte(run[j]) {
 				j++
 			}
-			// Alt 1: [A-Z]+(?=[A-Z][a-z]) — need ≥2 uppers and rs[j] lower.
-			if j-i >= 2 && j < n && isLower(rs[j]) {
-				parts = append(parts, strings.ToLower(string(rs[i:j-1])))
+			// Alt 1: [A-Z]+(?=[A-Z][a-z]) — need ≥2 uppers and run[j] lower.
+			if j-i >= 2 && j < n && isLowerByte(run[j]) {
+				parts = append(parts, lowerString(run[i:j-1], scratch))
 				i = j - 1
 				continue
 			}
 			// Alt 2: [A-Z]?[a-z]+ — one upper here + lowercase tail.
-			if j < n && isLower(rs[j]) {
+			if j < n && isLowerByte(run[j]) {
 				k := j
-				for k < n && isLower(rs[k]) {
+				for k < n && isLowerByte(run[k]) {
 					k++
 				}
-				parts = append(parts, strings.ToLower(string(rs[i:k])))
+				parts = append(parts, lowerString(run[i:k], scratch))
 				i = k
 				continue
 			}
-			// Alt 3: [A-Z]+ — pure uppercase (no following lowercase).
-			parts = append(parts, strings.ToLower(string(rs[i:j])))
+			// Alt 3: [A-Z]+ — pure uppercase (no lowercase follows).
+			parts = append(parts, lowerString(run[i:j], scratch))
 			i = j
-		case isLower(r):
+		case isLowerByte(c):
 			j := i + 1
-			for j < n && isLower(rs[j]) {
+			for j < n && isLowerByte(run[j]) {
 				j++
 			}
-			parts = append(parts, string(rs[i:j]))
+			// Already lowercase — emit the view directly (fast path).
+			parts = append(parts, run[i:j])
 			i = j
-		case isDigit(r):
+		case isDigitByte(c):
 			j := i + 1
-			for j < n && isDigit(rs[j]) {
+			for j < n && isDigitByte(run[j]) {
 				j++
 			}
-			parts = append(parts, string(rs[i:j]))
+			parts = append(parts, run[i:j])
 			i = j
 		default:
 			// Unreachable: caller filters underscores and non-ASCII.

--- a/internal/bm25/tokenize_test.go
+++ b/internal/bm25/tokenize_test.go
@@ -2,6 +2,7 @@ package bm25
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -71,6 +72,182 @@ func TestTokenize_IdentifierSplitting(t *testing.T) {
 		got := Tokenize(c.in)
 		if !reflect.DeepEqual(got, c.want) {
 			t.Errorf("Tokenize(%q) = %v, want %v", c.in, got, c.want)
+		}
+	}
+}
+
+// TestTokenize_AdversarialParity is the v0.8.5-tokenizer-allocs load-bearing
+// parity contract. The cases stress edge behavior the IdentifierSplitting
+// suite may not exhaustively cover — each expected value was computed
+// against the rune-based pre-refactor implementation on main HEAD
+// (`41b6ca7`) so any refactor that changes Tokenize's byte-equal output on
+// these inputs is, by definition, a semantics regression.
+//
+// Per the v0.8.5 briefing: "if parity holds, NDCG@10 is mathematically
+// required to be identical (top-K-by-score is deterministic on identical-
+// token inputs)." Token-set parity is a stronger safety net than the
+// downstream NDCG check — it's the test that catches subtle tokenizer
+// drift before it propagates through scoring.
+func TestTokenize_AdversarialParity(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want []string
+	}{
+		// ── Empty / whitespace-only / pure-punctuation: no runs ───────
+		{"whitespace-spaces", "   ", nil},
+		{"whitespace-mixed", "\n\t\n", nil},
+		{"punctuation-symbols", "!@#$%^&*()", nil},
+		{"punctuation-arrow", "-->", nil},
+
+		// ── Camel + acronym + digit shape (briefing-listed) ───────────
+		{"XMLParser2", "XMLParser2", []string{"xmlparser2", "xml", "parser", "2"}},
+		// "camelCaseToken" — 1 compound + 3 parts.
+		{"camelCaseToken", "camelCaseToken", []string{"camelcasetoken", "camel", "case", "token"}},
+		// "HTTPResponse" — uppercase-acronym + word.
+		{"HTTPResponse", "HTTPResponse", []string{"httpresponse", "http", "response"}},
+
+		// ── Snake variants: leading / trailing / multiple underscores ─
+		// Snake split drops EMPTY parts; the compound preserves the
+		// underscores. `__init__` → empty,empty,init,empty,empty → only
+		// "init" survives the filter → len(parts)=1 → ONLY compound.
+		{"leading-underscore", "_leading_underscore", []string{"_leading_underscore", "leading", "underscore"}},
+		{"trailing-underscore", "trailing_underscore_", []string{"trailing_underscore_", "trailing", "underscore"}},
+		{"double-underscores", "__double__underscores__", []string{"__double__underscores__", "double", "underscores"}},
+
+		// ── Digit-start runs: digits cannot start a TOKEN_RE match ────
+		// `42is_not_an_identifier`: '4'/'2' rejected, 'i' starts run that
+		// continues across digits/letters/underscores → "is_not_an_identifier"
+		// → snake-split → 4 non-empty parts. The "42" prefix is dropped
+		// because no identifier byte preceded it as a start.
+		{"digit-start-prefix", "42is_not_an_identifier", []string{"is_not_an_identifier", "is", "not", "an", "identifier"}},
+		// `_42_is`: '_' IS a valid start; run extends across the digits +
+		// underscores + letters. Snake-split → ["", "42", "is"] → drop
+		// empty → ["42", "is"]. len=2 → compound + parts.
+		{"underscore-digits", "_42_is", []string{"_42_is", "42", "is"}},
+
+		// ── Non-ASCII input: rune-based and byte-based scanning produce
+		// identical output because UTF-8 multi-byte sequences use only
+		// 0x80-0xFF bytes (never in the ASCII identifier ranges 0x30-39,
+		// 0x41-5A, 0x5F, 0x61-7A), so byte-level scan correctly treats
+		// non-ASCII as a run-terminator-or-non-starter.
+		{"naive-with-diacritic", "naïve", []string{"na", "ve"}},
+		// 测试_user: '测' + '试' are non-ASCII (3-byte UTF-8 each, no
+		// identifier bytes anywhere in the sequence), then '_user' is a
+		// single run. compound + parts after snake-split → ["_user"]
+		// since the only non-empty part is "user" (len=1 → only compound).
+		{"chinese-then-underscore-ident", "测试_user", []string{"_user"}},
+
+		// ── Real-source: realistic mixed identifier shapes ────────────
+		// The expected output was computed by hand-tracing the Tokenize
+		// algorithm against the pre-refactor rune-based impl. Order:
+		// "func" → 1; "ValidateUser" → 3 (compound + camel parts);
+		// "req" → 1; "http" → 1; "Request" → 1; "error" → 1;
+		// "if" → 1; "req" → 1; "nil" → 1; "return" → 1;
+		// "errors" → 1; "New" → 1; "nil" (in string) → 1.
+		{
+			name: "real-source-go-snippet",
+			in:   `func ValidateUser(req *http.Request) error {` + "\n\t" + `if req == nil { return errors.New("nil") }` + "\n}",
+			want: []string{
+				"func",
+				"validateuser", "validate", "user",
+				"req",
+				"http",
+				"request",
+				"error",
+				"if",
+				"req",
+				"nil",
+				"return",
+				"errors",
+				"new",
+				"nil",
+			},
+		},
+
+		// ── Buffer-pool stress: ensure no scratch-buffer corruption
+		// across many tokenize calls on the same input. The assertion
+		// is that re-tokenizing produces stable output (catches a
+		// pool-leak that would manifest as cross-call mutation).
+		{"stress-stable-1", "alpha BetaGamma delta_epsilon HTTP2", []string{
+			"alpha",
+			"betagamma", "beta", "gamma",
+			"delta_epsilon", "delta", "epsilon",
+			"http2", "http", "2",
+		}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := Tokenize(c.in)
+			if !reflect.DeepEqual(got, c.want) {
+				t.Errorf("Tokenize(%q) =\n  got:  %v\n  want: %v", c.in, got, c.want)
+			}
+		})
+	}
+}
+
+// TestTokenize_StablePoolReuse verifies that pooled scratch buffers don't
+// leak state between calls — re-running Tokenize on the same input must
+// produce identical output across many iterations.
+func TestTokenize_StablePoolReuse(t *testing.T) {
+	inputs := []string{
+		"camelCase snake_case HTTPParser XMLBuilder2 abc123",
+		"validate_user_input_with_long_name AndPascalCase",
+		"naïve 测试_user _42_is __init__",
+	}
+	// Establish expected by running once per input on a fresh pool state.
+	want := make(map[string][]string, len(inputs))
+	for _, in := range inputs {
+		want[in] = Tokenize(in)
+	}
+	// Replay each input many times; output must match the first-run
+	// expectation byte-for-byte every time.
+	const iterations = 100
+	for i := 0; i < iterations; i++ {
+		for _, in := range inputs {
+			got := Tokenize(in)
+			if !reflect.DeepEqual(got, want[in]) {
+				t.Fatalf("iteration %d, Tokenize(%q) drifted:\n  got:  %v\n  want: %v",
+					i, in, got, want[in])
+			}
+		}
+	}
+}
+
+// TestTokenize_LongInputNoPanic exercises a multi-kilobyte realistic input
+// to ensure the refactored tokenizer (with its pooled scratch buffer)
+// scales without panic or buffer-pool corruption. Verifies the function
+// produces a deterministic, non-empty result; doesn't pin specific token
+// counts since those depend on the deterministic-but-elaborate generator.
+func TestTokenize_LongInputNoPanic(t *testing.T) {
+	// Deterministic 4 KiB input mixing identifier shapes.
+	var b strings.Builder
+	const target = 4 * 1024
+	templates := []string{
+		"func handleRequest(req *HTTPRequest, ctx Context) (*Response, error) ",
+		"if user_id == 42 { return errors.New(\"bad input\") }",
+		"var camelCaseVar HTTPParser XMLBuilder2 = newInstance()",
+		"// comment with snake_case_words and CamelCase mixed_together\n",
+	}
+	for b.Len() < target {
+		for _, t := range templates {
+			b.WriteString(t)
+			b.WriteByte('\n')
+		}
+	}
+	input := b.String()
+
+	// Multiple calls must produce identical output (pool-stability check
+	// at scale).
+	first := Tokenize(input)
+	if len(first) == 0 {
+		t.Fatal("Tokenize returned no tokens for 4 KiB realistic input")
+	}
+	for i := 0; i < 10; i++ {
+		got := Tokenize(input)
+		if !reflect.DeepEqual(got, first) {
+			t.Fatalf("iteration %d drifted from first call (lens %d vs %d)",
+				i, len(got), len(first))
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Second Ship-tier perf fix from the [ADR-025](docs/DECISIONS.md#adr-025-perf-campaign-phase-1-investigation-outcome--hotspot-identification-across-small--medium-workloads) hotspot ranking: cut BM25 tokenizer allocations dramatically while preserving `Tokenize` output **byte-identically**. The byte-level scan + pooled scratch + lowercase fast-path together drop tokenizer wall time **−49.5%** and tokenizer alloc count **−58.7%** at the unit level, translating to **−32.9% bm25-regex indexing wall time** at medium scale via the GC time saved.

## Calibration evidence (Apple M1 Pro / Go 1.26.3 / darwin/arm64)

**benchstat** (10 iter each, all `p=0.000`):

| | rune-based | byte-based | Δ |
|---|---|---|---|
| Tokenize sec/op | 530.8µs | 267.8µs | **−49.5%** |
| Tokenize B/s | 47.36 MiB | 93.87 MiB | **+98.2%** |
| Tokenize B/op | 398.7 KiB | 318.9 KiB | −20.0% |
| Tokenize allocs/op | 13,600 | 5,613 | **−58.7%** |

**End-to-end medium-corpus** (`scripts/perf_collect.sh medium --modes=bm25,hybrid --chunkers=regex`, 378,524 chunks):

| combo | metric | rune-based | byte-based | Δ |
|---|---|---|---|---|
| bm25-regex INDEX | wall | 59.8s | **40.1s** | **−32.9%** |
| bm25-regex INDEX | objects allocated | 301.9M | 133.6M | **−55.7%** |
| bm25-regex INDEX | heap inuse | 6.41 GB | 5.96 GB | −7.0% |
| bm25-regex SEARCH | p50 | 1.78 ms | 1.76 ms | ≈ noise |
| hybrid-regex INDEX | wall | 192.8s | 166.8s | **−13.5%** |
| hybrid-regex INDEX | heap inuse | 9.13 GB | **5.71 GB** | **−37.5%** |
| hybrid-regex SEARCH | p50 | 117.9 ms | 124.1 ms | +5% (noise) |

Search latency unchanged within noise — the refactor only touches the indexing tokenizer path. Hybrid heap drop (−37.5%) is the most-surprising win: lowercase tokens now share storage with the chunk text (the lowerString fast-path returns the source string view) rather than being independent copies.

**NDCG@10 safety check** (semble bench corpus, 63 repos / 1251 tasks, all 3 modes, `--chunker regex` both sides):

| mode | BEFORE | AFTER | Δ |
|---|---|---|---|
| bm25 | 0.6237 | 0.6237 | **0.0000 (exact)** |
| semantic | 0.6469 | 0.6469 | **0.0000 (exact)** |
| hybrid | 0.8418 | 0.8418 | **0.0000 (exact)** |

Token-set parity proof bears out — same tokens in → same scores → same K results → identical ranking → identical NDCG.

## Test plan

- [x] `gofmt -l cmd internal` clean
- [x] `go vet ./...` clean
- [x] `go build ./...` ok
- [x] `go test ./...` green (incl. 16 new adversarial parity cases + 2 stability tests + the existing 28-case IdentifierSplitting suite)
- [x] benchstat (10 iter, all `p=0.000`) — see ADR-027
- [x] End-to-end medium re-measurement (bm25 + hybrid × regex, BEFORE and AFTER)
- [x] NDCG@10 clean-BEFORE vs AFTER for all 3 modes — all exact match

## Why byte-level scanning is parity-safe on non-ASCII input

UTF-8 multi-byte sequences use only 0x80-0xFF bytes; the ASCII identifier ranges (0x30-0x39, 0x41-0x5A, 0x5F, 0x61-0x7A) are all < 0x80. The two ranges don't overlap, so a non-ASCII byte cannot false-positive as an identifier start and CORRECTLY terminates any in-progress run. The parity tests pin this with `naïve` (Latin diacritic) and `测试_user` (Chinese + ASCII identifier) cases.

## Notes

- **Two commits:** [`6042be5`](https://github.com/townsendmerino/ken/commit/6042be5) (adversarial parity tests) + [`0530f48`](https://github.com/townsendmerino/ken/commit/0530f48) (refactor + ADR-027).
- **Public API unchanged** — `Tokenize(text string) []string` and the documented identifier-extraction + split semantics preserved per [ADR-008](docs/DECISIONS.md#adr-008-bm25-tokenizer--verbatim-port-of-sembles-tokenspy-snake-case-compound-preservation)'s verbatim-parity contract.
- **No new third-party dependencies.** Refactor uses only standard library.
- **B/op shortfall vs briefing projection** (−20% vs projected −50-80%): the fast-path's zero-alloc case only fires for already-lowercase identifiers; real-source corpora have many mixed-case identifiers taking the slow path (still 1 alloc, vs 2 before). The allocs/op metric (−58.7%) is the more representative signal. Documented in ADR-027 Consequences.
- **Briefing's deferred items:** `bm25.Build` map-lookup optimization with `m[string(b)]` pattern (would require `Tokenize` returning `[][]byte` — rejected for API-invasiveness; v0.8.6+ candidate after a re-measurement).

Generated with [Claude Code](https://claude.com/claude-code)