### PR TITLE
fix(lint): cmd/ken/perf.go errcheck on deferred os.RemoveAll + wix.Close

### DIFF
--- a/cmd/ken/perf.go
+++ b/cmd/ken/perf.go
@@ -424,7 +424,7 @@ func cmdPerfWatch(args []string) int {
 		fmt.Fprintln(os.Stderr, "ken: "+err.Error())
 		return 1
 	}
-	defer os.RemoveAll(tmp)
+	defer func() { _ = os.RemoveAll(tmp) }()
 
 	if err := copyTree(rest[0], tmp); err != nil {
 		fmt.Fprintln(os.Stderr, "ken: copy corpus to temp: "+err.Error())
@@ -447,7 +447,7 @@ func cmdPerfWatch(args []string) int {
 		return 1
 	}
 	initialIndexMs := float64(time.Since(initStart).Microseconds()) / 1000.0
-	defer wix.Close()
+	defer func() { _ = wix.Close() }()
 
 	// Single-slot flush channel so we never block the debouncer goroutine.
 	// Drained at the top of each edit iteration so each measurement is


### PR DESCRIPTION
## Summary

CI's golangci-lint flagged two unchecked error returns in cmd/ken/perf.go's `perf watch` subcommand:

```
cmd/ken/perf.go:427:20: Error return value of `os.RemoveAll` is not checked (errcheck)
cmd/ken/perf.go:450:17: Error return value of `wix.Close` is not checked (errcheck)
```

Both are deferred cleanup calls where the error is genuinely uninteresting (the temp dir is being deleted at process exit; the WatchedIndex's debouncer-goroutine reaper returns nil by design per [ADR-012](docs/DECISIONS.md#adr-012-incremental-indexing-via-fsnotify--atomic-snapshot-swap)). Wrapping in `defer func() { _ = ... }()` is the canonical Go idiom for "ignore the error intentionally."

Two-line change, no behavior change.

## Test plan

- [x] `gofmt -l cmd internal` clean
- [x] `go vet ./...` clean
- [x] `go build ./...` ok
- [x] No test changes; existing tests unaffected (internal lifecycle hooks only)

## Notes

Lands separate from v0.8.5 ([#25](https://github.com/townsendmerino/ken/pull/25)) so the scope of each PR stays clean — v0.8.5's work is in `internal/bm25/` and shares no files with this fix.

Generated with [Claude Code](https://claude.com/claude-code)