### PR TITLE
perf(v0.8.6): BM25 tokenizer parts-slice pooling via tokBuffers struct

### DIFF
--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -33,6 +33,7 @@ ADR statuses: **Proposed** (documenting design alternatives; no implementation d
 | [ADR-025](#adr-025-perf-campaign-phase-1-investigation-outcome--hotspot-identification-across-small--medium-workloads) | Perf-campaign Phase 1 investigation outcome — hotspot identification across small + medium workloads | Accepted |
 | [ADR-026](#adr-026-paired-heap-refactor-for-annflatquery--bm25indextopk-v084) | Paired heap refactor for `ann.Flat.Query` + `bm25.Index.TopK` via shared `internal/topk` (v0.8.4) | Accepted |
 | [ADR-027](#adr-027-bm25-tokenizer-allocation-reduction--rune--byte--syncpool-scratch--lowercase-fast-path-v085) | BM25 tokenizer allocation reduction (`[]rune` → `[]byte` + `sync.Pool` scratch + lowercase fast-path) (v0.8.5) | Accepted |
+| [ADR-028](#adr-028-bm25-tokenizer-parts-slice-pooling-via-tokbuffers-struct-v086) | BM25 tokenizer `parts`-slice pooling via `tokBuffers` struct (v0.8.6) | Accepted |
 
 ---
 
@@ -1706,3 +1707,143 @@ Refactor `internal/bm25/tokenize.go` to scan input bytes directly (instead of de
 - **No new third-party dependencies.** Refactor uses only standard library (`strings`, `sync`). Drops two prior dependencies inside the file (`slices`, `strings.SplitSeq`/`strings.ToLower`/`strings.IndexByte`) in favor of the byte-direct equivalents.
 
 - **Future perf work informed.** Post-v0.8.5, the remaining ADR-025 hotspots are: `bm25.Build`'s 37.6% indexing-alloc share (potentially addressable via `m[string(b)]` lookup pattern — deferred to v0.8.6+ pending a re-measurement that shows it's still worth the API churn), and the embed pipeline (`weightedMeanPoolSafe` accumulator at 23% of small hybrid CPU — gated on a pure-Go-no-cgo SIMD pattern). GC pressure should drop substantially with this refactor in tree, which will shift the relative shares.
+
+---
+
+## ADR-028: BM25 tokenizer `parts`-slice pooling via `tokBuffers` struct (v0.8.6)
+
+**Status:** Accepted
+
+**Date:** 2026-05-27
+
+**Issue:** TBD (open a townsendmerino/ken issue for the v0.8.6 work + cross-link on merge).
+
+**Extends:** [ADR-027](#adr-027-bm25-tokenizer-allocation-reduction--rune--byte--syncpool-scratch--lowercase-fast-path-v085) (the v0.8.5 byte-level scan + scratch pool that this builds on), [ADR-025](#adr-025-perf-campaign-phase-1-investigation-outcome--hotspot-identification-across-small--medium-workloads) (the GC-is-~50%-of-indexing-CPU finding that makes object count the right lever), [ADR-008](#adr-008-bm25-tokenizer--verbatim-port-of-sembles-tokenspy-snake-case-compound-preservation) (the verbatim-parity contract this refactor explicitly preserves).
+
+### Context
+
+After ADR-027 shipped, a post-v0.8.5 re-measurement of `ken perf index` at medium scale (semble bench corpus, 378,524 chunks) revealed that the allocation picture had split into two distinct shapes — by bytes vs by object count — and the GC-time lever was on the object-count side:
+
+**By bytes (alloc_space, 17.2 GB total):** `bm25.Build` 41.8% ≈ tokenizer 42.1% — roughly tied.
+
+**By object count (alloc_objects, 111M total) — the GC-pressure signal:**
+
+```
+bm25.camelSplitBytes   75.8M flat  68.1%   ← the target
+bm25.lowerString       20.8M       18.7%
+bm25.emitRun→Tokenize 102.3M cum   91.9%
+bm25.Build              5.5M        4.9%
+```
+
+The tokenizer accounted for **92% of indexing allocation COUNT but only 42% of bytes**. `bm25.Build` was the byte hog (a few large structures: ~1.3 KB/object map buckets + posting slices); the tokenizer was the count hog (tens of millions of tiny `parts []string` slices, one per identifier). GC mark cost scales with object count + pointer density, not raw bytes, and [ADR-025](#adr-025-perf-campaign-phase-1-investigation-outcome--hotspot-identification-across-small--medium-workloads) measured GC at ~50% of indexing CPU. So the GC-time lever for v0.8.6 was specifically `camelSplitBytes`'s 75.8M `parts`-slice allocations.
+
+Root cause: `camelSplitBytes` returned a fresh `parts []string` per identifier; the snake-split path in `emitRun` did the same with a local `var parts`. Those string headers were copied into the output via `append(out, parts...)`, so the `parts` backing array was dead-and-reusable the instant the append completed. The fix is to stop allocating it per-identifier.
+
+### Decision
+
+Extend [ADR-027](#adr-027-bm25-tokenizer-allocation-reduction--rune--byte--syncpool-scratch--lowercase-fast-path-v085)'s pooled `*[]byte` scratch into a small `*tokBuffers` struct holding **both** `scratch []byte` (for lowercase conversion) AND `parts []string` (for sub-token accumulation). One `sync.Pool` Get/Put per `Tokenize` call; the `parts` slice is reset to length 0 at the top of each `emitRun` and refilled via the snake- or camel-split path; at the bottom, contents are copied into the output via `append(out, bufs.parts...)`.
+
+Two surface changes:
+
+1. **`tokBuffers` struct** holds `{scratch []byte, parts []string}`. Pooled via `sync.Pool`; initial capacities cover typical identifier shape (scratch 256 bytes, parts 16 entries).
+2. **`camelSplitBytes` → `camelSplitBytesInto(run string, bufs *tokBuffers)`.** Appends directly into `bufs.parts` instead of returning a fresh slice. The signature couples the camel splitter to the buffer struct, but the struct is per-call state owned by Tokenize so the coupling is local and reads naturally.
+
+`lowerString` signature is unchanged (still takes `scratch *[]byte`); callers pass `&bufs.scratch`.
+
+The correctness argument has three load-bearing pieces:
+
+- **`append(out, bufs.parts...)` COPIES string headers** into out's backing array. After the append, `bufs.parts`'s backing array holds nothing `out` depends on.
+- **The string DATA those headers point at is independent of `bufs`:** lowerString's fast-path returns a view into `text` (valid as long as text lives, no bufs dependency); lowerString's slow-path returns a fresh allocation copied out of `bufs.scratch` (also no bufs dependency after the conversion).
+- So `bufs.parts` can hold a mix of both, and copying them into `out` then reusing `bufs.parts[:0]` for the next identifier is safe. Same reasoning that made ADR-027's scratch reuse safe, extended one level.
+
+### Alternatives considered
+
+- **Pre-size `parts := make([]string, 0, 8)` per call instead of pooling.** Simpler — just a constant-cap allocation per call — but still 1 alloc/identifier. Halves the per-identifier count rather than eliminating it. Rejected: the pooled-struct refactor gets to ~0 amortized; pre-sizing leaves half the win on the table for marginal code-simplicity gain.
+
+- **Pool `parts` separately from `scratch` (two `sync.Pool` instances).** Rejected. One struct holding both keeps Tokenize to a single Get/Put pair per call; two pools doubles the per-call overhead without any compensating benefit. The two buffers are always acquired and released together by the same caller, so the natural shape is one pooled struct.
+
+- **Attack `bm25.Build` (the byte hog) instead.** Rejected for v0.8.6. `bm25.Build` is 41.8% of indexing alloc BYTES but only 4.9% of indexing alloc OBJECTS — so it's a memory-footprint target, not a GC-time target. Heap-inuse already dropped to ~5.5 GB post-v0.8.5; reducing bm25.Build's byte share would help RSS but not GC pressure. Documented as v0.8.7+ candidate if RSS becomes the explicit goal; the natural fix shape (`m[string(b)]` lookup pattern) requires changing `Tokenize` to return `[][]byte` which is explicitly rejected by [ADR-008](#adr-008-bm25-tokenizer--verbatim-port-of-sembles-tokenspy-snake-case-compound-preservation) (the function-level byte-equality contract is on the `[]string` output).
+
+- **Pass `parts *[]string` to `camelSplitBytesInto` instead of `*tokBuffers`** (looser coupling). Considered. The single-argument signature is marginally cleaner but exposes the buffer-of-buffers shape less clearly. Took the struct parameter because emitRun ALSO needs `bufs.scratch` (passed through to `lowerString` for case conversion), and the consistency of "all internal helpers take the struct" reads better than mixing parameter styles.
+
+- **Change `Tokenize`'s public signature to expose buffer reuse to callers** (e.g., `Tokenize(text string, bufs *tokBuffers)`). Rejected — public API stays exactly as ADR-008 / ADR-027 documented. The internal-only pool achieves the same amortization without leaking the buffer plumbing to callers.
+
+### Consequences
+
+**Measured impact** (Apple M1 Pro / Go 1.26.3 / darwin/arm64 / `CGO_ENABLED=0 -trimpath -ldflags='-s -w'`):
+
+- **`Tokenize` micro-benchmark** (`go test -bench BenchmarkTokenize -benchmem -count=10`, before = main HEAD with v0.8.5 byte-based code, after = this commit):
+
+  ```
+              │  v0.8.5 byte-based  │  v0.8.6 pooled-parts                │
+              │      sec/op         │      sec/op           vs base       │
+  Tokenize    │  292.7µs ± 1%       │  207.4µs ± 18%        −29.1% (p=0.000) │
+
+              │      B/s            │      B/s              vs base       │
+  Tokenize    │  85.90 MiB/s ± 1%   │  121.19 MiB/s ± 15%   +41.1% (p=0.000) │
+
+              │      B/op           │      B/op             vs base       │
+  Tokenize    │  318.9 KiB ± 0%     │  244.4 KiB ± 0%       −23.4% (p=0.000) │
+
+              │      allocs/op      │      allocs/op        vs base       │
+  Tokenize    │  5,613 ± 0%         │  1,463 ± 0%           −73.9% (p=0.000) │
+  ```
+
+  **The allocs/op −73.9% reduction is the headline v0.8.6 metric.** This is the GC-pressure lever the briefing identified — the per-identifier `parts` slice allocations are gone. The AFTER sec/op variance (±18%) is high relative to BEFORE (±1%) because the AFTER number is now small enough that timer noise dominates — `p=0.000` still holds (the diff is significant), but treat the central tendency as a range, not a point estimate.
+
+- **End-to-end medium-corpus re-measurement** (`scripts/perf_collect.sh medium --modes=bm25,hybrid --chunkers=regex`, 378,524 chunks):
+
+  | combo | metric | v0.8.5 | v0.8.6 | Δ |
+  |---|---|---|---|---|
+  | bm25-regex INDEX | objects allocated | 133.6M | **53.5M** | **−60.0%** |
+  | bm25-regex INDEX | bytes allocated | 16.86 GB | 15.04 GB | −10.8% |
+  | bm25-regex INDEX | heap inuse | 5.96 GB | 5.54 GB | −7.0% |
+  | bm25-regex INDEX | wall time | 40.1s | 52.4s | +30.7% (variance, see below) |
+  | bm25-regex SEARCH | p50 | 1.76 ms | 1.88 ms | +7% (within noise) |
+  | hybrid-regex INDEX | objects allocated | 652.0M | 571.9M | −12.3% |
+  | hybrid-regex INDEX | bytes allocated | 51.56 GB | 49.74 GB | −3.5% |
+  | hybrid-regex INDEX | heap inuse | 5.71 GB | 5.64 GB | −1% (noise) |
+  | hybrid-regex INDEX | wall time | 166.8s | 216.8s | +30% (variance, see below) |
+  | hybrid-regex SEARCH | p50 | 124.07 ms | 132.73 ms | +7% (within noise) |
+
+  **Object-count win is the load-bearing signal:** bm25-regex INDEX drops 133.6M → 53.5M objects (−60%) — the camelSplitBytes 75.8M and the snake-path `var parts` allocations together. Hybrid-regex INDEX's smaller drop (−12.3%) is expected: hybrid's allocations are dominated by the embed pipeline (which v0.8.6 doesn't touch); the tokenizer's share of hybrid's allocs is much smaller.
+
+  **Wall-time AFTER numbers are dominated by machine-load variance on this measurement window, not a v0.8.6 regression.** Three independent observations support this:
+    1. The benchstat AFTER variance was ±18% (vs ±1% BEFORE) — consistent with high system contention.
+    2. The NDCG-bench wall times for v0.8.6 (bm25 5.7→7.8s, semantic 23.3→28.4s, hybrid 50.4→59.6s — all +20-25%) showed the same uniform slowdown — a single-cause signature.
+    3. The object-count win (−60%) and the alloc_objects pprof confirmation (below) are machine-independent and unambiguous.
+
+  A second measurement window with the machine quieter would likely show wall-time improvement on the order of the briefing's −15-30% projection. Documented honestly here: the object-count win is real and reproducible; the wall-time delta on this specific run isn't a clean signal.
+
+- **`alloc_objects` pprof top — the headline confirmation** (`go tool pprof -top -sample_index=alloc_objects bench_out/medium/2026-05-27/profiles/bm25-regex.index.mem.pprof`):
+
+  ```
+                  flat  flat%   sum%        cum   cum%
+    22,448,951   66.47% 66.47% 22,448,951  66.47%  bm25.lowerString (inline)
+     5,229,215   15.48% 81.95%  5,229,215  15.48%  bm25.Build
+     3,195,012    9.46% 91.41% 25,643,973  75.93%  bm25.emitRun
+     ...
+            10  3e-05%         9,033,193   26.75%  bm25.camelSplitBytesInto    ← was 75.8M / 68.1% pre-v0.8.6
+  ```
+
+  `bm25.camelSplitBytesInto` flat allocations dropped from 75.8M (68.1%) to **10 objects** — essentially eliminated. The function still appears in the cumulative column (it calls `lowerString` for slow-path lowercases) but no longer allocates its own data. Total live-alloc objects: ~33.7M (down from ~111M pre-v0.8.6 — the records.jsonl 53.5M figure is the larger `alloc_delta` across the entire index build including walk/chunk overhead).
+
+- **NDCG@10 safety check** (semble bench corpus, 63 repos / 1251 tasks, all 3 modes, `--chunker regex` both sides):
+
+  | mode | v0.8.5 NDCG@10 | v0.8.6 NDCG@10 | Δ |
+  |---|---|---|---|
+  | bm25 | 0.6237 | 0.6237 | **0.0000** (exact) |
+  | semantic | 0.6469 | 0.6469 | **0.0000** (exact) |
+  | hybrid | 0.8418 | 0.8418 | **0.0000** (exact) |
+
+  Exact match in all three modes confirms token-set parity: same tokens in → same scores → same K results → same ranking → identical NDCG. The buffer-reuse refactor introduced no semantic drift, which is the load-bearing safety property `TestTokenize_AdversarialParity`'s 17 cases (including the new `within-call-parts-reuse` stress) are designed to catch.
+
+- **Token-set parity test extension.** Added one new case to `TestTokenize_AdversarialParity`: `within-call-parts-reuse` ("aB cD_eF gHiJkL m_n_o PQRSTuv") — five consecutive identifiers of rapidly varying part counts (2/2/4/3/2). This is the specific bug shape v0.8.6 could introduce: cross-identifier contamination via the shared `parts` slice if its backing array isn't properly reset between `emitRun` calls. The existing `stress-stable-1` covers 4-identifier reuse; `TestTokenize_LongInputNoPanic` covers many-identifier reuse via the 4 KiB stress input; the new case adds a focused mid-scale variant.
+
+- **No public API changes.** `Tokenize(text string) []string` signature unchanged. Public callers (`bm25.Build`, query-side tokenization, external consumers via the `Tokenize` symbol) see identical behavior.
+
+- **No new third-party dependencies.** Refactor uses only standard library (`strings`, `sync`).
+
+- **The accumulating second-machine-confirmation debt** ([`docs/PERF.md`](PERF.md) acceptance threshold step 2): ADR-026, ADR-027, and now ADR-028 have all shipped with single-machine evidence (Apple M1 Pro / native arm64 darwin / Go 1.26.3). This is the THIRD perf release in the v0.8.x cycle without a second-machine confirmation, and the briefing explicitly flagged: "Don't let it slide silently a fourth time." Before any further perf release (v0.8.7+), we either set up a Linux x86_64 CI confirmation runner OR consciously decide single-machine evidence is sufficient for this class of change and amend the acceptance threshold accordingly. Token-set parity (which load-bears each of these releases) is machine-independent, so the safety check holds across architectures; the wall-time and alloc numbers do not, and that's where the debt accumulates.
+
+- **Future perf work informed.** Post-v0.8.6, the alloc_objects picture has shifted: `bm25.lowerString` is now the dominant flat frame at 66.47% (22.4M objects — these are the slow-path string allocations for tokens containing uppercase bytes; the byte-level lowercase work is the bottleneck). `bm25.Build` is 15.48% (5.2M — map insertions, the natural next target if RSS becomes a goal). The embed pipeline is unchanged and untouched by ADR-027 or ADR-028. Any v0.8.7+ briefing should rank against this updated profile, not the post-v0.8.5 one this ADR motivated against.

--- a/internal/bm25/tokenize.go
+++ b/internal/bm25/tokenize.go
@@ -24,8 +24,10 @@
 //     "validate", "user"]` (compound first), not `["validate", "user"]`.
 //     CamelCase splitting matches the `_CAMEL_RE` regex's ordered
 //     alternation. See ADR-008 for why verbatim parity is the contract,
-//     and ADR-027 for the v0.8.5 alloc-reduction refactor that
-//     preserves byte-equality of Tokenize output.
+//     ADR-027 for the v0.8.5 byte-level scan refactor, and ADR-028 for
+//     the v0.8.6 parts-slice pooling that eliminates the per-identifier
+//     allocation overhead. All three releases preserve token output
+//     byte-identically.
 package bm25
 
 import (
@@ -33,15 +35,30 @@ import (
 	"sync"
 )
 
-// tokenizerScratch pools per-call scratch byte buffers used by lowerString
-// for lowercase conversion. Starting cap of 256 bytes covers the typical
-// identifier-length distribution; the buffer grows automatically for rare
-// long identifiers and Put resets length but keeps cap. Sharing across
-// goroutines is fine — sync.Pool is the canonical Go idiom for this.
-var tokenizerScratch = sync.Pool{
+// tokBuffers holds the per-call reusable scratch buffers. Pooled so they
+// amortize across the millions of Tokenize calls an index build makes.
+//
+//   - scratch: lowercase conversion target (v0.8.5 / ADR-027). Grown as
+//     needed by lowerString's slow path; reset to length 0 on Put.
+//   - parts:   identifier sub-token accumulator (v0.8.6 / ADR-028). Reset
+//     to length 0 at the top of each emitRun, refilled via the snake- or
+//     camel-split path, then string headers are COPIED into the output
+//     slice via append. The backing array is therefore safe to reuse
+//     for the next identifier — out has its own copies.
+//
+// Initial scratch cap covers typical identifier length; initial parts
+// cap covers typical identifier sub-token count.
+type tokBuffers struct {
+	scratch []byte
+	parts   []string
+}
+
+var tokenizerPool = sync.Pool{
 	New: func() any {
-		b := make([]byte, 0, 256)
-		return &b
+		return &tokBuffers{
+			scratch: make([]byte, 0, 256),
+			parts:   make([]string, 0, 16),
+		}
 	},
 }
 
@@ -68,23 +85,28 @@ var tokenizerScratch = sync.Pool{
 //   - Sub-tokenization follows `split_identifier`: if `_` is in the run,
 //     split on `_` (drop empties) — no camel recursion inside the parts.
 //     Otherwise camelCase-split via the same `_CAMEL_RE` regex, modeled
-//     by camelSplitBytes below.
+//     by camelSplitBytesInto below.
 //   - Output order is `[compound, *parts]` (compound first), matching
 //     semble.split_identifier exactly.
 //
-// Implementation note (v0.8.5 / ADR-027): scans bytes directly rather
-// than decoding UTF-8 runes. The byte-level scan produces output
-// byte-identical to a rune-based scan on non-ASCII input because UTF-8
-// multi-byte sequences use only 0x80-0xFF bytes — never in the ASCII
-// identifier ranges (0x30-0x39, 0x41-0x5A, 0x5F, 0x61-0x7A) — so a
-// non-ASCII byte correctly terminates any run-in-progress and cannot
-// false-positive as an identifier start. TestTokenize_AdversarialParity
-// pins this with explicit non-ASCII cases.
+// Implementation note (v0.8.5+v0.8.6, ADR-027+ADR-028): scans bytes
+// directly rather than decoding UTF-8 runes. The byte-level scan
+// produces output byte-identical to a rune-based scan on non-ASCII
+// input because UTF-8 multi-byte sequences use only 0x80-0xFF bytes —
+// never in the ASCII identifier ranges (0x30-0x39, 0x41-0x5A, 0x5F,
+// 0x61-0x7A) — so a non-ASCII byte correctly terminates any run-in-
+// progress and cannot false-positive as an identifier start. Both the
+// scratch buffer (for lowercase conversion) and the parts accumulator
+// (for sub-token assembly) are pooled across Tokenize calls so per-
+// identifier allocations drop to near-zero in steady state.
+// TestTokenize_AdversarialParity pins this with explicit non-ASCII
+// cases + a within-call parts-reuse stress case.
 func Tokenize(text string) []string {
-	bufPtr := tokenizerScratch.Get().(*[]byte)
+	bufs := tokenizerPool.Get().(*tokBuffers)
 	defer func() {
-		*bufPtr = (*bufPtr)[:0]
-		tokenizerScratch.Put(bufPtr)
+		bufs.scratch = bufs.scratch[:0]
+		bufs.parts = bufs.parts[:0]
+		tokenizerPool.Put(bufs)
 	}()
 
 	var out []string
@@ -103,11 +125,11 @@ func Tokenize(text string) []string {
 			continue
 		}
 		// Non-identifier byte ends the current run at i (exclusive).
-		out = emitRun(text[runStart:i], bufPtr, out)
+		out = emitRun(text[runStart:i], bufs, out)
 		runStart = -1
 	}
 	if runStart >= 0 {
-		out = emitRun(text[runStart:], bufPtr, out)
+		out = emitRun(text[runStart:], bufs, out)
 	}
 	return out
 }
@@ -116,8 +138,23 @@ func Tokenize(text string) []string {
 // run to out. Dispatches to the snake- or camel-split path based on
 // whether the run contains an underscore byte. Single-part runs emit
 // only the compound.
-func emitRun(run string, scratch *[]byte, out []string) []string {
-	compound := lowerString(run, scratch)
+//
+// bufs.parts is reset to length 0 at the top and used as the
+// accumulator for sub-tokens; at the bottom, len(bufs.parts) is checked
+// and the contents copied into out via append. The backing array is
+// safe to reuse next call because:
+//
+//   - String headers in bufs.parts are copied byte-by-byte into out's
+//     backing array by `append`; out's strings don't alias bufs.parts.
+//   - The string DATA (the underlying bytes those headers point at) is
+//     either a view into text (lowerString fast path — independent of
+//     bufs) or a fresh allocation copied out of bufs.scratch (slow path
+//     — also independent of subsequent bufs mutation).
+//   - So neither out's slice nor its strings depend on bufs.parts'
+//     backing array after the append completes.
+func emitRun(run string, bufs *tokBuffers, out []string) []string {
+	compound := lowerString(run, &bufs.scratch)
+	bufs.parts = bufs.parts[:0]
 
 	if strings.IndexByte(run, '_') >= 0 {
 		// Snake split: iterate the run looking for '_' boundaries.
@@ -125,30 +162,25 @@ func emitRun(run string, scratch *[]byte, out []string) []string {
 		// lets each part take the lowerString fast-path when it's
 		// already lowercase. Empty parts (consecutive '_' or leading/
 		// trailing '_') are filtered, matching semble's `if p`.
-		var parts []string
 		start := 0
 		for i := 0; i <= len(run); i++ {
 			if i == len(run) || run[i] == '_' {
 				if i > start {
-					parts = append(parts, lowerString(run[start:i], scratch))
+					bufs.parts = append(bufs.parts, lowerString(run[start:i], &bufs.scratch))
 				}
 				start = i + 1
 			}
 		}
-		if len(parts) >= 2 {
-			out = append(out, compound)
-			out = append(out, parts...)
-		} else {
-			out = append(out, compound)
-		}
-		return out
+	} else {
+		// camelCase split: operates on byte offsets into run; appends
+		// directly into bufs.parts so we don't allocate a fresh slice
+		// per identifier.
+		camelSplitBytesInto(run, bufs)
 	}
 
-	// camelCase split: operates on byte offsets into run.
-	parts := camelSplitBytes(run, scratch)
-	if len(parts) >= 2 {
+	if len(bufs.parts) >= 2 {
 		out = append(out, compound)
-		out = append(out, parts...)
+		out = append(out, bufs.parts...)
 	} else {
 		out = append(out, compound)
 	}
@@ -164,12 +196,12 @@ func emitRun(run string, scratch *[]byte, out []string) []string {
 //     this path.
 //   - Slow: copies s into scratch with uppercase bytes lowered, then
 //     returns `string(scratch)`. Exactly one allocation regardless of
-//     input length (vs the pre-refactor pattern's two: rune→string +
+//     input length (vs the pre-ADR-027 pattern's two: rune→string +
 //     strings.ToLower).
 //
 // scratch is a pooled byte buffer; emitRun's caller (Tokenize) owns it
-// and resets length on Put. lowerString resets it to zero length before
-// each use.
+// via tokBuffers and resets length on Put. lowerString resets it to
+// zero length before each slow-path use.
 func lowerString(s string, scratch *[]byte) string {
 	for i := 0; i < len(s); i++ {
 		if s[i] >= 'A' && s[i] <= 'Z' {
@@ -203,14 +235,22 @@ func isUpperByte(c byte) bool { return c >= 'A' && c <= 'Z' }
 func isLowerByte(c byte) bool { return c >= 'a' && c <= 'z' }
 func isDigitByte(c byte) bool { return c >= '0' && c <= '9' }
 
-// camelSplitBytes is the byte-level port of the v0.8.4-and-earlier
-// camelSplit. Operates on a run that contains only [a-zA-Z0-9] (no
-// underscores) and returns lowercased sub-tokens in match order. Uses
-// scratch for per-part lowercasing via lowerString; runs of pure
-// lowercase or digits hit the fast path and are returned as views into
-// the source.
+// camelSplitBytesInto is the byte-level camelCase splitter (verbatim
+// algorithm port of the pre-v0.8.5 camelSplit). Operates on a run that
+// contains only [a-zA-Z0-9] (no underscores) and appends lowercased
+// sub-tokens to bufs.parts in match order.
 //
-// Algorithm (verbatim semantics from the []rune version):
+// In v0.8.6 / ADR-028 this changed from returning a fresh `[]string`
+// to appending into the caller's pooled `bufs.parts` slice — eliminates
+// the per-identifier allocation that ADR-025's post-v0.8.5 pprof
+// identified as 68.1% of indexing allocation count (75.8M out of 111M
+// objects at medium scale). The string headers appended here are
+// either views into run (lowercase + digit fast-paths) or fresh
+// allocations out of bufs.scratch (uppercase slow path) — neither
+// aliases bufs.parts' backing array, so the caller can copy them into
+// the output slice and safely reuse bufs.parts on the next identifier.
+//
+// Algorithm (verbatim semantics from the pre-ADR-027 []rune version):
 //
 //	_CAMEL_RE = r"[A-Z]+(?=[A-Z][a-z])|[A-Z]?[a-z]+|[A-Z]+|[0-9]+"
 //
@@ -221,8 +261,7 @@ func isDigitByte(c byte) bool { return c >= '0' && c <= '9' }
 // lowercase and the run has ≥2 uppers, consume run[i:j-1] and let
 // run[j-1] start the next match. This is what splits "HTTPResponse"
 // into "HTTP" + "Response" and "XMLParser" into "XML" + "Parser".
-func camelSplitBytes(run string, scratch *[]byte) []string {
-	var parts []string
+func camelSplitBytesInto(run string, bufs *tokBuffers) {
 	n := len(run)
 	for i := 0; i < n; {
 		c := run[i]
@@ -234,7 +273,7 @@ func camelSplitBytes(run string, scratch *[]byte) []string {
 			}
 			// Alt 1: [A-Z]+(?=[A-Z][a-z]) — need ≥2 uppers and run[j] lower.
 			if j-i >= 2 && j < n && isLowerByte(run[j]) {
-				parts = append(parts, lowerString(run[i:j-1], scratch))
+				bufs.parts = append(bufs.parts, lowerString(run[i:j-1], &bufs.scratch))
 				i = j - 1
 				continue
 			}
@@ -244,12 +283,12 @@ func camelSplitBytes(run string, scratch *[]byte) []string {
 				for k < n && isLowerByte(run[k]) {
 					k++
 				}
-				parts = append(parts, lowerString(run[i:k], scratch))
+				bufs.parts = append(bufs.parts, lowerString(run[i:k], &bufs.scratch))
 				i = k
 				continue
 			}
 			// Alt 3: [A-Z]+ — pure uppercase (no lowercase follows).
-			parts = append(parts, lowerString(run[i:j], scratch))
+			bufs.parts = append(bufs.parts, lowerString(run[i:j], &bufs.scratch))
 			i = j
 		case isLowerByte(c):
 			j := i + 1
@@ -257,19 +296,18 @@ func camelSplitBytes(run string, scratch *[]byte) []string {
 				j++
 			}
 			// Already lowercase — emit the view directly (fast path).
-			parts = append(parts, run[i:j])
+			bufs.parts = append(bufs.parts, run[i:j])
 			i = j
 		case isDigitByte(c):
 			j := i + 1
 			for j < n && isDigitByte(run[j]) {
 				j++
 			}
-			parts = append(parts, run[i:j])
+			bufs.parts = append(bufs.parts, run[i:j])
 			i = j
 		default:
 			// Unreachable: caller filters underscores and non-ASCII.
 			i++
 		}
 	}
-	return parts
 }

--- a/internal/bm25/tokenize_test.go
+++ b/internal/bm25/tokenize_test.go
@@ -175,6 +175,23 @@ func TestTokenize_AdversarialParity(t *testing.T) {
 			"delta_epsilon", "delta", "epsilon",
 			"http2", "http", "2",
 		}},
+
+		// ── Within-call parts-slice reuse stress (v0.8.6 / ADR-028).
+		// Five consecutive identifiers of rapidly varying part counts
+		// (2/2/4/3/2 parts respectively). Catches the specific bug
+		// shape the v0.8.6 pooled-parts refactor could introduce:
+		// cross-identifier contamination via the shared `parts` slice
+		// if its backing array isn't properly reset between emitRun
+		// calls. Token-set parity here is the load-bearing safety net
+		// — same logic as v0.8.5's parity discipline, extended to the
+		// new pooled-parts shape.
+		{"within-call-parts-reuse", "aB cD_eF gHiJkL m_n_o PQRSTuv", []string{
+			"ab", "a", "b",
+			"cd_ef", "cd", "ef",
+			"ghijkl", "g", "hi", "jk", "l",
+			"m_n_o", "m", "n", "o",
+			"pqrstuv", "pqrs", "tuv",
+		}},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary

Third rolling perf fix in the v0.8.x cadence. v0.8.5 ([ADR-027](docs/DECISIONS.md#adr-027-bm25-tokenizer-allocation-reduction--rune--byte--syncpool-scratch--lowercase-fast-path-v085)) cut tokenizer allocation **bytes** via byte-level scan + scratch pool + lowercase fast-path. v0.8.6 cuts tokenizer allocation **count** by extending the pool to a `tokBuffers` struct holding both the v0.8.5 scratch byte buffer AND a reusable `parts []string` for sub-token accumulation. Same load-bearing constraint as v0.8.5: `Tokenize` output preserved byte-identically.

The post-v0.8.5 re-measurement at medium scale showed the tokenizer was **92% of indexing allocation COUNT** (vs 42% of allocation bytes), with `camelSplitBytes` alone at 68.1% (75.8M of 111M total objects). GC mark cost scales with object count, so this was the GC-time lever — distinct from v0.8.5's byte lever.

## Calibration evidence (Apple M1 Pro / Go 1.26.3 / darwin/arm64)

**benchstat Tokenize** (10 iter each, all `p=0.000`):

| | v0.8.5 | v0.8.6 | Δ |
|---|---|---|---|
| sec/op | 292.7 µs | 207.4 µs | **−29.1%** |
| B/s | 85.90 MiB | 121.19 MiB | **+41.1%** |
| B/op | 318.9 KiB | 244.4 KiB | −23.4% |
| **allocs/op** | **5,613** | **1,463** | **−73.9%** ← headline |

**End-to-end medium-corpus** (`scripts/perf_collect.sh medium --modes=bm25,hybrid --chunkers=regex`, 378,524 chunks):

| combo | metric | v0.8.5 | v0.8.6 | Δ |
|---|---|---|---|---|
| **bm25-regex INDEX** | **objects allocated** | **133.6M** | **53.5M** | **−60.0%** ← headline |
| bm25-regex INDEX | bytes allocated | 16.86 GB | 15.04 GB | −10.8% |
| bm25-regex INDEX | heap inuse | 5.96 GB | 5.54 GB | −7.0% |
| hybrid-regex INDEX | objects allocated | 652.0M | 571.9M | −12.3% |
| hybrid-regex INDEX | bytes allocated | 51.56 GB | 49.74 GB | −3.5% |

(hybrid's smaller drop is expected — hybrid's allocations are dominated by the embed pipeline which v0.8.6 doesn't touch.)

**Wall times went up ~30% on the AFTER pass** across all measurements (NDCG bench wall +20-25%, benchstat AFTER variance ±18% vs BEFORE ±1%). This is **machine-load variance on this measurement window, not a v0.8.6 regression** — documented honestly in [ADR-028](docs/DECISIONS.md#adr-028-bm25-tokenizer-parts-slice-pooling-via-tokbuffers-struct-v086) Consequences. The object-count win is the load-bearing signal; wall-time delta isn't a clean read this run.

**`alloc_objects` pprof confirmation:**

```
                flat  flat%        cum   cum%
  22,448,951   66.47%      22,448,951  66.47%  bm25.lowerString
   5,229,215   15.48%       5,229,215  15.48%  bm25.Build
   3,195,012    9.46%      25,643,973  75.93%  bm25.emitRun
          10  3e-05%        9,033,193  26.75%  bm25.camelSplitBytesInto  ← was 75.8M / 68.1% pre-v0.8.6
```

camelSplitBytesInto flat allocations: **75.8M → 10 objects**. Essentially eliminated.

**NDCG@10 safety check** (all 3 modes, regex chunker both sides):

| mode | v0.8.5 | v0.8.6 | Δ |
|---|---|---|---|
| bm25 | 0.6237 | 0.6237 | **0.0000 (exact)** |
| semantic | 0.6469 | 0.6469 | **0.0000 (exact)** |
| hybrid | 0.8418 | 0.8418 | **0.0000 (exact)** |

Token-set parity proof bears out — same tokens in → identical NDCG.

## Test plan

- [x] `gofmt -l cmd internal` clean
- [x] `go vet ./...` clean
- [x] `go build ./...` ok
- [x] `go test ./...` green (incl. new `within-call-parts-reuse` parity case + existing 28-case IdentifierSplitting + 16 prior adversarial + 2 stability tests)
- [x] benchstat (10 iter, all `p=0.000`)
- [x] End-to-end medium re-measurement + alloc_objects pprof top
- [x] NDCG@10 exact-match for all 3 modes

## Briefing judgment calls

1. **Single `tokBuffers` struct vs two separate pools** — took the single struct (one Get/Put per Tokenize call; less ceremony than two pools).
2. **`camelSplitBytesInto` signature** — passes `*tokBuffers` (briefing's all-internal-helpers-take-the-struct option; emitRun already threads the struct, so consistency wins over slightly looser coupling).
3. **Added `within-call-parts-reuse` parity case** — briefing's exact example (`"aB cD_eF gHiJkL m_n_o PQRSTuv"`, parts counts 2/2/4/3/2). Catches the specific cross-identifier contamination bug shape pooled parts could introduce.

## Accumulating second-machine debt (flagged in ADR-028)

This is the **third single-machine perf release** (ADR-026, ADR-027, ADR-028 all M1 Pro / arm64 only). Per the briefing: before v0.8.7+, either set up a Linux x86_64 CI confirmation runner OR consciously amend the acceptance threshold in `docs/PERF.md`. Token-set parity is machine-independent (load-bearing safety holds across archs); wall-time and alloc numbers are not, and that's where the debt accumulates.

## Notes

- **Single commit** [`e84c918`](https://github.com/townsendmerino/ken/commit/e84c918) (tokenizer refactor + new parity case + ADR-028).
- **Public API unchanged** — `Tokenize(text string) []string` and the [ADR-008](docs/DECISIONS.md#adr-008-bm25-tokenizer--verbatim-port-of-sembles-tokenspy-snake-case-compound-preservation) verbatim-parity contract preserved.
- **No new third-party dependencies.** Refactor uses only standard library.
- **Post-v0.8.6 alloc_objects picture has shifted:** `bm25.lowerString` is now the dominant flat frame (66.47%, 22.4M objects) — slow-path string allocations for mixed-case identifiers. `bm25.Build` is 15.48% (the next target if RSS becomes the goal).

Generated with [Claude Code](https://claude.com/claude-code)