### PR TITLE
perf(db): parallelize mysqlAppendSamples + ADR-031 (v0.8.8); Postgres deferred-with-trigger

### DIFF
--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -36,6 +36,7 @@ ADR statuses: **Proposed** (documenting design alternatives; no implementation d
 | [ADR-028](#adr-028-bm25-tokenizer-parts-slice-pooling-via-tokbuffers-struct-v086) | BM25 tokenizer `parts`-slice pooling via `tokBuffers` struct (v0.8.6) | Accepted |
 | [ADR-029](#adr-029-v08x-perf-campaign-capstone--allocationgc-ceiling-reached-indexing-is-single-threaded-parallelism-is-the-next-frontier) | v0.8.x perf campaign capstone — allocation/GC ceiling reached; indexing is single-threaded; parallelism is the next frontier | Accepted (extended by ADR-030) |
 | [ADR-030](#adr-030-indexing-pipeline-parallelism--phase-a-per-file-workers-for-chunk--embed-v087) | Indexing pipeline parallelism — Phase A (per-file workers for chunk + embed) (v0.8.7) | Accepted |
+| [ADR-031](#adr-031-mysql-introspection-sample-loop-parallelism-postgres-deferred-with-trigger-v088) | MySQL introspection sample-loop parallelism; Postgres deferred-with-trigger (v0.8.8) | Accepted |
 
 ---
 
@@ -2154,3 +2155,108 @@ After Phase A, the indexing wall-time profile shifts:
 - A post-Phase-A re-measurement shows `bm25.Build` is the bottleneck on a workload pattern semble medium doesn't represent.
 
 Without one of those triggers, the parallelism campaign closes here. Phase A is the publication; Phase B is documented future work.
+
+
+---
+
+## ADR-031: MySQL introspection sample-loop parallelism; Postgres deferred-with-trigger (v0.8.8)
+
+**Status:** Accepted
+
+**Date:** 2026-05-27
+
+**Issue:** TBD (cross-link when opened).
+
+**Extends:** [ADR-019](#adr-019-mysql-engine--schema-filtering-for-multi-schema-dev-databases) (the MySQL introspection engine — Phase A2 parallelizes its hottest loop), [ADR-021](#adr-021-mariadb-first-class-engine-support-v081-part-b) (MariaDB shares the same introspection path), [ADR-017](#adr-017-database-schema-indexing--two-tier-static-sql--live-postgres-with-documented-pii-stance) (Postgres introspection — the deferred Phase A2 target), [ADR-030](#adr-030-indexing-pipeline-parallelism--phase-a-per-file-workers-for-chunk--embed-v087) (the indexing-pipeline analogue; same predict-measure-decide discipline).
+
+### Context
+
+A second-opinion review of `internal/db/mysql.go` flagged `mysqlAppendSamples` as a candidate for `errgroup` parallelism: `*sql.DB` is goroutine-safe by design, each table's sample fetch is independent, and the per-table writes target distinct `&snap.tables[i]` slots so no synchronization is needed.
+
+Initial skepticism (worth recording, because it was wrong): the sample loop runs once per reindex, the SQL is `LIMIT 5` over indexed PKs, and intuition said it would be a small fraction of total introspection wall time. The v0.8.x perf-campaign discipline (instrument-before-optimizing, see [ADR-029](#adr-029-v08x-perf-campaign-capstone--allocationgc-ceiling-reached-indexing-is-single-threaded-parallelism-is-the-next-frontier)) said: measure before deciding.
+
+A new `//go:build dbperf`-gated harness (`internal/db/mysql_perf_test.go`, mirrored by `postgres_perf_test.go`) was added with a 50-tables × 100-rows synthetic fixture per engine. Sequential baselines on Apple M1 Pro / Go 1.26.3 / Docker localhost MySQL 8 + Postgres 16:
+
+| metric | MySQL | Postgres |
+|---|---|---|
+| sample-loop wall (3-trial median) | 43.7 ms | 22.7 ms |
+| full introspection wall | 76.6 ms | 90.9 ms |
+| **sample-loop fraction of total** | **57.0%** | **25.0%** |
+| Amdahl ceiling (8 workers) | **2.0×** | 1.28× |
+
+**MySQL falsified the initial skepticism hard** — the sample loop is the single biggest contributor to introspection wall time on localhost, and the per-table latency-bound shape (median 813 µs, dominated by query round-trip + Go-side decode) is exactly what `errgroup` fans out cleanly.
+
+**Postgres was borderline** on localhost (25%, ceiling 1.28×). Phase A2 needed to account for the engine asymmetry rather than assume symmetric architecture would yield symmetric wins.
+
+### Decision
+
+**Parallelize `mysqlAppendSamples` via `errgroup.SetLimit(sampleWorkers())`. Defer Postgres parallelism with an explicit re-open trigger.**
+
+#### MySQL: parallelize
+
+`mysqlAppendSamples` (`internal/db/mysql.go`) wraps each table's sample fetch in `g.Go(func() error { ...; return nil })` over an `errgroup.WithContext`. `sampleWorkers()` returns `min(8, runtime.NumCPU())` — bounded so the parallel pass never exceeds shared dev/staging MySQL `max_connections` (commonly 50–150). The `*sql.DB` opened in `indexSchemaMySQL` is capped with `SetMaxOpenConns(sampleWorkers())` so the pool size matches the worker count and there's no race between "burst of 8 goroutines" and "MySQL connection limit."
+
+Workers return `nil` unconditionally — per-table failures keep the existing `warn+continue` semantics. Returning `err` would cause `errgroup.WithContext` to cancel siblings on the first failure, which is the wrong shape for a best-effort sample pass.
+
+Output ordering is preserved because per-table results are written to `&snap.tables[i]` (a pre-existing distinct slot per table); the `snap.tables` slice itself is built once before the parallel pass.
+
+#### Postgres: deferred-with-trigger
+
+`sampleRowsImpl` (`internal/db/sample.go`) stays sequential in v0.8.8. The architectural obstacle is real: `*pgx.Conn` is NOT goroutine-safe (the pgx contract is one-goroutine-per-conn), so the Postgres path can't fan out across the existing connection. The investigated alternative — a scoped `pgxpool.Pool` opened just for the sample pass — was implemented and measured:
+
+| metric | Postgres sequential (baseline) | Postgres scoped-pgxpool (parallel) |
+|---|---|---|
+| sampleRowsImpl wall (3-trial median) | 22.7 ms | 21.7 ms |
+| full introspection wall | 90.9 ms | 94.7 ms |
+
+**Localhost measurement: net wash.** Pool setup overhead (open 8 connections, warmup, teardown) approximately equals the parallelism gain on the 50-table × 100-row fixture. The architectural shape works (pool teardown is clean, no race conditions, integration tests pass `-race`), but the *measured benefit on localhost is zero*.
+
+The load-bearing case for Postgres parallelism is **remote DBs** where per-query latency is RTT-bound (5–50 ms per `SELECT`). Synthetic estimate: at 30 ms RTT × 50 tables = 1.5 s sequential vs ~200 ms parallel = 7–8× speedup, and the sample-loop fraction shoots from 25% to ~70% of total introspection. **But we don't have a remote-DB measurement to publish.**
+
+Per the v0.8.x discipline ("measured wins only"), Postgres parallelism stays out of v0.8.8. The harness lives in `internal/db/postgres_perf_test.go` as the regression baseline; the scoped-pgxpool implementation was reverted (kept in git history at the v0.8.8-db-parallelism branch's pre-revert state if a future reader wants to consult it).
+
+**Phase A2-Postgres re-opens** when:
+- A real user reports Postgres introspection latency as actionable pain on a remote DB (managed RDS / Aurora / etc.), OR
+- A remote-DB run of `postgres_perf_test.go` (with `KEN_DB_TEST_DSN` pointed at a real-network endpoint) shows the sample-loop fraction climbs past ~50% and parallel impl wins ≥1.5× on full introspection wall time.
+
+### Alternatives considered
+
+- **Parallelize Postgres anyway with localhost-caveat disclosure.** Rejected. The v0.8.x discipline is "measured wins only" — shipping unmeasured architecture is exactly the pattern ADR-029 closed out. Localhost is where most CI / dev / first-touch users will exercise the introspection; a measured wash there is not a release-worthy upgrade.
+- **Migrate the whole Postgres introspection to `pgxpool.Pool` wholesale.** Rejected as scope-creep for v0.8.8. The original ADR-017 chose `*pgx.Conn` deliberately (introspection is one-shot per reindex; pooling adds complexity for no benefit). Reversing that decision needs its own ADR with its own measurement — concurrent metadata queries, connection lifetime under listen.go's separate LISTEN connection, etc. — not a side effect of a sample-loop parallelism release.
+- **Synthetic latency injection in the harness (sleep N ms per query) to "prove" the remote case.** Rejected. Synthetic latency isn't network latency — TCP backoff, MySQL/Postgres-side query pipelining, kernel scheduling under real load all behave differently from `time.Sleep`. A synthetic-but-meaningful measurement is still a single-machine experiment; it would land Postgres parallelism on artifice, not evidence.
+- **Bigger fan-out for MySQL (16 or 32 workers).** Rejected. `min(8, NumCPU())` matches the indexing-pipeline ADR-030 pattern; the 8-cap protects shared MySQL servers; the measured 1.85× speedup is already 92% of the 2.0× Amdahl ceiling — diminishing returns past 8.
+- **`errgroup` without `SetLimit`.** Rejected. Without the limit, a 200-table schema would spawn 200 goroutines and 200 connection requests simultaneously, blowing past MySQL's `max_connections` on shared servers. The `SetLimit + SetMaxOpenConns` pair is two belts (errgroup-side + pool-side) for one suspender.
+- **Drop the pre-walk approxRowCount attach step from the parallel section.** Kept inside the parallel guard for clarity; technically the attach pass touches `t.approxRowCount` before the parallel pass begins, so there's no race with workers (which only write `t.sampleColumns` + `t.sampleRows`).
+
+### Consequences
+
+**Measured impact** (Apple M1 Pro / Go 1.26.3 / darwin/arm64 / Docker localhost MySQL 8 / 50 tables × 100 rows / 3-trial medians):
+
+| metric | post-v0.8.7 (sequential) | post-v0.8.8 (parallel) | Δ |
+|---|---|---|---|
+| **mysqlAppendSamples wall** | 43.7 ms | **19.2 ms** | **−56% (2.28× speedup)** |
+| **MySQL full introspection wall** | 76.6 ms | **41.4 ms** | **−46% (1.85× speedup)** |
+| sample-loop fraction of total | 57.0% | 46.3% | shrunk proportionally |
+
+1.85× on full MySQL introspection is **92% of the 2.0× Amdahl ceiling** — minimal scheduling/coordination overhead, the parallel impl cashes nearly all of the theoretical max.
+
+**Postgres unchanged** in v0.8.8: sampleRowsImpl 22.7 ms / full introspection 90.9 ms / sample-loop fraction 25.0%. Re-opens on the trigger above.
+
+- **Output ordering preserved.** `TestMySQLIntegration_RowSamplingDeterministic` (the load-bearing parity test for sample-row determinism) passes `-race` clean post-parallel. Per-table writes target distinct `&snap.tables[i]` slots; the `snap.tables` slice itself is built once before the parallel pass and never mutated by workers.
+- **`-race` clean across the full integration suite.** `go test -tags=dbintegration -race -run TestMySQLIntegration ./internal/db/` passes all 5 subtests.
+- **Pool cap protects shared servers.** `*sql.DB.SetMaxOpenConns(sampleWorkers())` bounds the pool to ≤8 connections even on a 16-core box. The errgroup limit + the pool cap together guarantee no shared-MySQL connection exhaustion regardless of how many goroutines an upstream caller spawns.
+- **No new third-party dependencies.** `runtime` (stdlib), `golang.org/x/sync/errgroup` (already in go.mod).
+- **Public API unchanged.** `mysqlAppendSamples` is package-private; `IndexSchema` signature is unchanged; ken-mcp and `mcp/db` see no surface change.
+- **Harnesses live in tree as regression baselines.** Both `mysql_perf_test.go` and `postgres_perf_test.go` are gated by `//go:build dbperf` so they don't run in normal `go test ./...`. The Postgres harness exists deliberately even though Postgres isn't parallelized — it's the proof of work for the "deferred-with-trigger" decision and the harness that re-opens Phase A2-Postgres when remote-DB users surface latency pain.
+- **Honest disclosure on engine asymmetry.** v0.8.8 is the first DB-introspection release that has measurably different speedup across engines. MySQL gets a clean 1.85× win; Postgres + SQLite are unchanged. Users running ken-mcp against the Tier-2 DB path will see the gain only when DSN points at MySQL/MariaDB.
+- **The "fast-path optimization" precursor was rejected.** Before this work, a second-opinion review proposed adding `if !strings.Contains(s, "(")` short-circuit to `normalizeMySQLIntType`. Correctness-preserving but the savings were below measurement noise (~0.2% of introspection wall — 150 calls × ~1 µs each = ~150 µs saved out of 77 ms). Rejecting it was the same discipline as accepting the Postgres deferral: don't ship what isn't measurably better.
+
+### What re-opens Phase B (parallel introspection metadata)
+
+After Phase A2, MySQL introspection wall is ~41 ms at medium scale. The remaining 22 ms is dominated by serial information_schema queries (constraints, indexes, FK references, views, routines). Each of these is a single big metadata query that has nowhere to fan out — they're already optimal in shape. Phase B would target running them concurrently against the same `*sql.DB`, saving perhaps another 10–15 ms.
+
+Phase B re-opens if:
+- A real user reports MySQL introspection on a giant-schema deployment (thousands of tables, complex constraints) shows the metadata queries as the new bottleneck.
+- The harness's full-introspection median climbs past 100 ms on a representative workload — meaning per-table parallelism has shipped its win and the next layer is worth investigating.
+
+Without one of those triggers, the parallelism work closes at v0.8.8.

--- a/docs/PERF.md
+++ b/docs/PERF.md
@@ -135,6 +135,20 @@ The follow-on campaign ADR-029 scoped landed as v0.8.7. The pipeline now paralle
 
 See [ADR-030](DECISIONS.md#adr-030-indexing-pipeline-parallelism--phase-a-per-file-workers-for-chunk--embed-v087) for the architecture, alternatives considered (Phase B sharded `bm25.Build` deferred-with-trigger; stage-based pipeline rejected; opt-in flag rejected), and the deferred concerns (giant-scale memory ceiling, second-machine confirmation as a user-action follow-up). The next perf campaign is not auto-queued — Phase A closes the parallelism investigation at its scoped target; Phase B re-opens only on a concrete user-pain trigger.
 
+### v0.8.8 DB-introspection parallelism (2026-05-27) — MySQL sample loop, Postgres deferred
+
+Same predict-measure-decide loop, smaller scope. A second-opinion review flagged `mysqlAppendSamples` as an `errgroup` candidate. Initial skepticism (sample LIMIT 5 over indexed PKs should be cheap) was falsified by measurement: a new `//go:build dbperf`-gated harness (50 tables × 100 rows synthetic fixture) showed MySQL sample-loop wall is **57% of total introspection** with an Amdahl ceiling of 2.0×. Postgres' sample-loop was only 25% of its total (Amdahl ceiling 1.28×), and a measured implementation via scoped `pgxpool` came out essentially flat on localhost (22.7 ms → 21.7 ms) because pool-setup overhead ate the parallelism gain. Per v0.8.x discipline, Postgres parallelism was reverted; MySQL shipped.
+
+| metric | post-v0.8.7 (sequential) | post-v0.8.8 (MySQL parallel) | Δ |
+|---|---|---|---|
+| mysqlAppendSamples wall | 43.7 ms | **19.2 ms** | **2.28×** |
+| MySQL full introspection wall | 76.6 ms | **41.4 ms** | **1.85× (92% of Amdahl ceiling)** |
+| Postgres sampleRowsImpl wall | 22.7 ms | unchanged | — (deferred-with-trigger) |
+
+`TestMySQLIntegration_RowSamplingDeterministic` (the load-bearing sample-row determinism test) passes `-race` clean post-parallel. Output ordering is preserved by per-table writes targeting distinct `&snap.tables[i]` slots. The errgroup is bounded at `min(8, NumCPU())` and the introspection `*sql.DB` is matched via `SetMaxOpenConns(sampleWorkers())` so the pool can never exceed the worker count — two belts protecting shared dev/staging MySQL `max_connections`.
+
+See [ADR-031](DECISIONS.md#adr-031-mysql-introspection-sample-loop-parallelism-postgres-deferred-with-trigger-v088) for the full architecture, the Postgres deferral with its concrete re-open trigger (remote-DB user latency pain), and the rejected Gemini `normalizeMySQLIntType` fast-path (below-noise win — 0.2% — rejected by the same discipline that accepts the Postgres deferral).
+
 ## Files
 
 Landed:

--- a/internal/db/mysql.go
+++ b/internal/db/mysql.go
@@ -22,10 +22,12 @@ import (
 	"fmt"
 	"net/url"
 	"regexp"
+	"runtime"
 	"strings"
 	"time"
 
 	"github.com/go-sql-driver/mysql"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/townsendmerino/ken/internal/chunk"
 )
@@ -97,6 +99,12 @@ func indexSchemaMySQL(ctx context.Context, opts Options) ([]chunk.Chunk, error) 
 	if err != nil {
 		return nil, fmt.Errorf("db: mysql open: %w", err)
 	}
+	// Cap the pool at sampleWorkers() so the parallel sample fetch in
+	// mysqlAppendSamples never exceeds the configured worker count.
+	// Without this cap, *sql.DB defaults to unlimited connections and a
+	// burst of 8+ goroutines could exhaust shared MySQL max_connections.
+	// ADR-031.
+	conn.SetMaxOpenConns(sampleWorkers())
 	defer func() { _ = conn.Close() }()
 
 	if err := conn.PingContext(ctx); err != nil {
@@ -762,67 +770,110 @@ func mysqlAppendSamples(ctx context.Context, conn *sql.DB, snap *schemaSnapshot,
 		warn(opts, "mysql: row-count query failed: %v", err)
 	}
 
+	// Approx-count attach + per-table sample fetch.
+	//
+	// Sample fetches are fanned out across up to sampleWorkers goroutines
+	// via golang.org/x/sync/errgroup. *sql.DB is safe for concurrent use,
+	// and each worker writes to a distinct slice element (&snap.tables[i])
+	// so no cross-goroutine synchronization is needed for the per-table
+	// results. v0.8.4 / ADR-031: introspection sample loop is ~57% of
+	// total wall time on localhost (and dominates on remote DBs where
+	// per-query latency is RTT-bound); parallelism cashes the Amdahl
+	// ceiling.
+	//
+	// Workers return nil unconditionally — per-table failures are warned
+	// and swallowed (matches the pre-parallel warn+continue semantics).
+	// Returning err would cause errgroup.WithContext to cancel siblings
+	// on the first failure, which is the wrong shape for a best-effort
+	// sample pass.
 	for i := range snap.tables {
 		t := &snap.tables[i]
 		if c, ok := approx[t.schema+"."+t.name]; ok {
 			t.approxRowCount = c
 		}
-
-		orderClause := "ORDER BY 1"
-		for _, c := range t.columns {
-			if c.isPrimaryKey {
-				orderClause = "ORDER BY " + mysqlQuoteIdent(c.name)
-				break
-			}
-		}
-		// Fully-qualified schema.table; MySQL backticks for identifier safety.
-		q := fmt.Sprintf("SELECT * FROM %s.%s %s LIMIT ?",
-			mysqlQuoteIdent(t.schema), mysqlQuoteIdent(t.name), orderClause)
-		rows, err := conn.QueryContext(ctx, q, opts.SampleRows)
-		if err != nil {
-			warn(opts, "mysql: sample query failed for %s.%s: %v", t.schema, t.name, err)
-			continue
-		}
-		cols, err := rows.Columns()
-		if err != nil {
-			warn(opts, "mysql: column metadata for %s.%s: %v", t.schema, t.name, err)
-			rows.Close()
-			continue
-		}
-		t.sampleColumns = cols
-		var collected [][]string
-		for rows.Next() {
-			vals := make([]any, len(cols))
-			ptrs := make([]any, len(cols))
-			for j := range vals {
-				ptrs[j] = &vals[j]
-			}
-			if err := rows.Scan(ptrs...); err != nil {
-				warn(opts, "mysql: sample scan failed for %s.%s: %v", t.schema, t.name, err)
-				continue
-			}
-			cells := make([]string, len(vals))
-			for j, v := range vals {
-				// go-sql-driver/mysql returns VARCHAR / CHAR / TEXT / JSON
-				// as []byte rather than string (default driver behavior,
-				// unlike pgx which returns string). Convert at the
-				// driver boundary so formatCell renders them as the
-				// string they actually are. Genuine binary columns
-				// (BLOB / BINARY / VARBINARY) on MySQL also come back
-				// as []byte, but we let those render as strings too —
-				// formatCell's BYTEA path on Postgres still applies to
-				// pgx's []byte, where pgx only returns it for actual
-				// binary types.
-				if b, ok := v.([]byte); ok {
-					v = string(b)
-				}
-				cells[j] = truncateCell(formatCell(v))
-			}
-			collected = append(collected, cells)
-		}
-		rows.Close()
-		t.sampleRows = collected
 	}
+
+	g, gctx := errgroup.WithContext(ctx)
+	g.SetLimit(sampleWorkers())
+	for i := range snap.tables {
+		t := &snap.tables[i]
+		g.Go(func() error {
+			orderClause := "ORDER BY 1"
+			for _, c := range t.columns {
+				if c.isPrimaryKey {
+					orderClause = "ORDER BY " + mysqlQuoteIdent(c.name)
+					break
+				}
+			}
+			// Fully-qualified schema.table; MySQL backticks for identifier safety.
+			q := fmt.Sprintf("SELECT * FROM %s.%s %s LIMIT ?",
+				mysqlQuoteIdent(t.schema), mysqlQuoteIdent(t.name), orderClause)
+			rows, err := conn.QueryContext(gctx, q, opts.SampleRows)
+			if err != nil {
+				warn(opts, "mysql: sample query failed for %s.%s: %v", t.schema, t.name, err)
+				return nil
+			}
+			cols, err := rows.Columns()
+			if err != nil {
+				warn(opts, "mysql: column metadata for %s.%s: %v", t.schema, t.name, err)
+				rows.Close()
+				return nil
+			}
+			t.sampleColumns = cols
+			var collected [][]string
+			for rows.Next() {
+				vals := make([]any, len(cols))
+				ptrs := make([]any, len(cols))
+				for j := range vals {
+					ptrs[j] = &vals[j]
+				}
+				if err := rows.Scan(ptrs...); err != nil {
+					warn(opts, "mysql: sample scan failed for %s.%s: %v", t.schema, t.name, err)
+					continue
+				}
+				cells := make([]string, len(vals))
+				for j, v := range vals {
+					// go-sql-driver/mysql returns VARCHAR / CHAR / TEXT / JSON
+					// as []byte rather than string (default driver behavior,
+					// unlike pgx which returns string). Convert at the
+					// driver boundary so formatCell renders them as the
+					// string they actually are. Genuine binary columns
+					// (BLOB / BINARY / VARBINARY) on MySQL also come back
+					// as []byte, but we let those render as strings too —
+					// formatCell's BYTEA path on Postgres still applies to
+					// pgx's []byte, where pgx only returns it for actual
+					// binary types.
+					if b, ok := v.([]byte); ok {
+						v = string(b)
+					}
+					cells[j] = truncateCell(formatCell(v))
+				}
+				collected = append(collected, cells)
+			}
+			rows.Close()
+			t.sampleRows = collected
+			return nil
+		})
+	}
+	_ = g.Wait()
+}
+
+// sampleWorkers is the concurrency cap for parallel sample-row fetches
+// in both engines. Capped at 8 to avoid exhausting MySQL/Postgres
+// max_connections in shared dev/staging environments (commonly 50-150);
+// the matching SetMaxOpenConns(8) on the introspection *sql.DB further
+// guarantees we never exceed this. The min() with runtime.NumCPU() is
+// defensive — on a 2-core box, 8 workers would still serialize at the
+// scheduler anyway. ADR-031 documents the rationale.
+func sampleWorkers() int {
+	n := runtime.NumCPU()
+	if n > 8 {
+		n = 8
+	}
+	if n < 1 {
+		n = 1
+	}
+	return n
 }
 
 // mysqlApproxRowCounts returns a (schema.table → table_rows) map. Free

--- a/internal/db/mysql_perf_test.go
+++ b/internal/db/mysql_perf_test.go
@@ -1,0 +1,241 @@
+//go:build dbperf
+
+// One-off measurement harness — does NOT run as part of `go test ./...`.
+//
+// Question: is mysqlAppendSamples wall time a hotspot worth parallelizing
+// via errgroup? Per the perf-campaign discipline (instrument → measure
+// → decide), we measure before optimizing.
+//
+// To run:
+//
+//	docker run -d --rm --name ken-mysql-perf -p 53306:3306 \
+//	  -e MYSQL_ROOT_PASSWORD=test -e MYSQL_DATABASE=test mysql:8
+//	export KEN_DB_MYSQL_TEST_DSN='root:test@tcp(127.0.0.1:53306)/?parseTime=true'
+//	go test -tags=mysqlperf -run TestPerf_MySQLAppendSamples -v ./internal/db/
+//
+// What it measures:
+//   - Total mysqlAppendSamples wall time vs total introspection wall time
+//     (the % matters; if sample-fetch is <10% of total, parallelizing is moot).
+//   - Per-table sample-query wall time (sequential), so we can see whether
+//     time-per-table is roughly constant (parallelism wins) or bimodal
+//     (some tables dominate; parallelism wins less).
+//   - Where in the introspection pipeline time is actually spent
+//     (list-tables, annotate-constraints, annotate-indexes, annotate-FKs,
+//     list-views, list-routines, approx-row-counts, sample-loop).
+//
+// Fixture: 50 tables × 100 rows, mix of column shapes (int+text, int+timestamp,
+// int+varchar). Representative of a medium dev/staging MySQL.
+
+package db
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"os"
+	"sort"
+	"testing"
+	"time"
+
+	_ "github.com/go-sql-driver/mysql"
+)
+
+const (
+	perfSchema   = "ken_perf_samples"
+	perfTables   = 50
+	perfRowsPer  = 100
+	perfSampleN  = 5 // matches default sample-rows policy
+	perfWarmRuns = 1
+	perfTimedRun = 3 // median of 3
+)
+
+func TestPerf_MySQLAppendSamples(t *testing.T) {
+	dsn := os.Getenv("KEN_DB_MYSQL_TEST_DSN")
+	if dsn == "" {
+		t.Skip("set KEN_DB_MYSQL_TEST_DSN; see harness docstring")
+	}
+
+	ctx := context.Background()
+	conn, err := sql.Open("mysql", dsn)
+	if err != nil {
+		t.Fatalf("sql.Open: %v", err)
+	}
+	defer conn.Close()
+	if err := conn.PingContext(ctx); err != nil {
+		t.Fatalf("ping: %v", err)
+	}
+
+	// Build the fixture (idempotent: DROP + CREATE).
+	t.Logf("building fixture: %d tables × %d rows in schema %q...", perfTables, perfRowsPer, perfSchema)
+	buildStart := time.Now()
+	if err := perfBuildFixture(ctx, conn); err != nil {
+		t.Fatalf("fixture: %v", err)
+	}
+	t.Logf("fixture built in %v", time.Since(buildStart))
+	t.Cleanup(func() {
+		_, _ = conn.ExecContext(ctx, "DROP DATABASE IF EXISTS "+perfSchema)
+	})
+
+	// Warm the connection pool + MySQL caches.
+	for i := 0; i < perfWarmRuns; i++ {
+		_ = perfRunSampleLoop(ctx, conn)
+	}
+
+	// Per-table timing (sequential): captures the distribution.
+	t.Log("--- per-table sequential timing ---")
+	perTable, total := perfPerTableTiming(ctx, t, conn)
+	sort.Slice(perTable, func(i, j int) bool { return perTable[i] < perTable[j] })
+	min := perTable[0]
+	max := perTable[len(perTable)-1]
+	median := perTable[len(perTable)/2]
+	var sum time.Duration
+	for _, d := range perTable {
+		sum += d
+	}
+	mean := sum / time.Duration(len(perTable))
+	t.Logf("per-table sample-query wall: n=%d  min=%v  median=%v  mean=%v  max=%v  sum=%v  total_wall=%v",
+		len(perTable), min, median, mean, max, sum, total)
+
+	// Full mysqlAppendSamples timing (3-trial median).
+	t.Log("--- mysqlAppendSamples (full function) timing, 3 trials ---")
+	var trials []time.Duration
+	for i := 0; i < perfTimedRun; i++ {
+		d := perfRunSampleLoop(ctx, conn)
+		trials = append(trials, d)
+		t.Logf("trial %d: %v", i+1, d)
+	}
+	sort.Slice(trials, func(i, j int) bool { return trials[i] < trials[j] })
+	t.Logf("mysqlAppendSamples median of %d: %v", perfTimedRun, trials[perfTimedRun/2])
+
+	// Total introspection timing (the denominator — what fraction is sample-fetch?).
+	t.Log("--- full introspection (indexSchemaMySQL) timing, 3 trials ---")
+	var fullTrials []time.Duration
+	for i := 0; i < perfTimedRun; i++ {
+		opts := Options{DSN: dsn, SampleRows: perfSampleN, IncludeSchemas: []string{perfSchema}}
+		s := time.Now()
+		_, err := indexSchemaMySQL(ctx, opts)
+		if err != nil {
+			t.Fatalf("indexSchemaMySQL: %v", err)
+		}
+		fullTrials = append(fullTrials, time.Since(s))
+	}
+	sort.Slice(fullTrials, func(i, j int) bool { return fullTrials[i] < fullTrials[j] })
+	fullMedian := fullTrials[perfTimedRun/2]
+	sampleMedian := trials[perfTimedRun/2]
+	t.Logf("full introspection median: %v", fullMedian)
+	t.Logf("sample-loop fraction of total introspection: %.1f%%",
+		float64(sampleMedian)*100.0/float64(fullMedian))
+
+	// Verdict heuristic.
+	t.Log("--- verdict ---")
+	frac := float64(sampleMedian) / float64(fullMedian)
+	switch {
+	case frac < 0.10:
+		t.Logf("sample-loop is <10%% of introspection wall (%.1f%%) — parallelizing it is NOT worth the complexity", frac*100)
+	case frac < 0.30:
+		t.Logf("sample-loop is %.1f%% of introspection wall — borderline; ideal speedup would shave %.1f%% off worst case (Amdahl)", frac*100, frac*100*0.875)
+	default:
+		t.Logf("sample-loop is %.1f%% of introspection wall — parallelizing has real headroom; Amdahl ceiling ≈ %.1fx", frac*100, 1/(1-frac*0.875))
+	}
+}
+
+func perfBuildFixture(ctx context.Context, conn *sql.DB) error {
+	if _, err := conn.ExecContext(ctx, "DROP DATABASE IF EXISTS "+perfSchema); err != nil {
+		return err
+	}
+	if _, err := conn.ExecContext(ctx, "CREATE DATABASE "+perfSchema); err != nil {
+		return err
+	}
+	if _, err := conn.ExecContext(ctx, "USE "+perfSchema); err != nil {
+		return err
+	}
+	for i := 0; i < perfTables; i++ {
+		// Three table shapes, rotated, so the sample loop hits varied col types.
+		var createStmt string
+		switch i % 3 {
+		case 0:
+			createStmt = fmt.Sprintf(
+				"CREATE TABLE `t%03d` (id INT PRIMARY KEY, label TEXT, payload TEXT)", i)
+		case 1:
+			createStmt = fmt.Sprintf(
+				"CREATE TABLE `t%03d` (id INT PRIMARY KEY, label VARCHAR(64), updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP)", i)
+		case 2:
+			createStmt = fmt.Sprintf(
+				"CREATE TABLE `t%03d` (id INT PRIMARY KEY, score DOUBLE, json_blob JSON)", i)
+		}
+		if _, err := conn.ExecContext(ctx, createStmt); err != nil {
+			return fmt.Errorf("create t%03d: %w", i, err)
+		}
+		// Insert rows in one multi-row statement.
+		var values string
+		for r := 0; r < perfRowsPer; r++ {
+			if r > 0 {
+				values += ", "
+			}
+			switch i % 3 {
+			case 0:
+				values += fmt.Sprintf("(%d, 'label-%d', 'lorem ipsum dolor sit amet payload row %d')", r, r, r)
+			case 1:
+				values += fmt.Sprintf("(%d, 'label-%d', CURRENT_TIMESTAMP)", r, r)
+			case 2:
+				values += fmt.Sprintf(`(%d, %f, JSON_OBJECT('k', 'v', 'n', %d))`, r, float64(r)*1.5, r)
+			}
+		}
+		stmt := fmt.Sprintf("INSERT INTO `t%03d` VALUES %s", i, values)
+		if _, err := conn.ExecContext(ctx, stmt); err != nil {
+			return fmt.Errorf("insert t%03d: %w", i, err)
+		}
+	}
+	// ANALYZE so information_schema.tables.table_rows reflects reality.
+	for i := 0; i < perfTables; i++ {
+		_, _ = conn.ExecContext(ctx, fmt.Sprintf("ANALYZE TABLE `%s`.`t%03d`", perfSchema, i))
+	}
+	return nil
+}
+
+// perfRunSampleLoop replicates what mysqlAppendSamples does end-to-end on
+// our fixture, but without depending on the rest of the introspection
+// pipeline. We synthesize a minimal snapshot the function expects.
+func perfRunSampleLoop(ctx context.Context, conn *sql.DB) time.Duration {
+	// Build a minimal schemaSnapshot with the fixture tables.
+	snap := &schemaSnapshot{}
+	for i := 0; i < perfTables; i++ {
+		snap.tables = append(snap.tables, tableInfo{
+			schema: perfSchema,
+			name:   fmt.Sprintf("t%03d", i),
+			columns: []columnInfo{
+				{name: "id", isPrimaryKey: true},
+			},
+		})
+	}
+	opts := Options{SampleRows: perfSampleN, IncludeSchemas: []string{perfSchema}}
+	start := time.Now()
+	mysqlAppendSamples(ctx, conn, snap, opts)
+	return time.Since(start)
+}
+
+func perfPerTableTiming(ctx context.Context, t *testing.T, conn *sql.DB) ([]time.Duration, time.Duration) {
+	durations := make([]time.Duration, 0, perfTables)
+	totalStart := time.Now()
+	for i := 0; i < perfTables; i++ {
+		name := fmt.Sprintf("t%03d", i)
+		q := fmt.Sprintf("SELECT * FROM `%s`.`%s` ORDER BY `id` LIMIT ?", perfSchema, name)
+		s := time.Now()
+		rows, err := conn.QueryContext(ctx, q, perfSampleN)
+		if err != nil {
+			t.Fatalf("sample query %s: %v", name, err)
+		}
+		cols, _ := rows.Columns()
+		for rows.Next() {
+			vals := make([]any, len(cols))
+			ptrs := make([]any, len(cols))
+			for j := range vals {
+				ptrs[j] = &vals[j]
+			}
+			_ = rows.Scan(ptrs...)
+		}
+		rows.Close()
+		durations = append(durations, time.Since(s))
+	}
+	return durations, time.Since(totalStart)
+}

--- a/internal/db/postgres_perf_test.go
+++ b/internal/db/postgres_perf_test.go
@@ -1,0 +1,201 @@
+//go:build dbperf
+
+// One-off measurement harness for Postgres — does NOT run as part of
+// `go test ./...`. Sibling to mysql_perf_test.go; same shape so the
+// engine asymmetry is auditable in one place.
+//
+// To run:
+//
+//	docker run -d --rm --name ken-postgres-perf -p 55432:5432 \
+//	  -e POSTGRES_PASSWORD=test postgres:16-alpine
+//	export KEN_DB_TEST_DSN='postgres://postgres:test@127.0.0.1:55432/postgres?sslmode=disable'
+//	go test -tags=dbperf -run TestPerf_PostgresSampleRows -v ./internal/db/
+//
+// Fixture: 50 tables × 100 rows, mix of column shapes (int+text+text,
+// int+varchar+timestamp, int+double+jsonb). Mirrors the MySQL harness
+// for direct cross-engine comparison.
+
+package db
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+)
+
+const (
+	pgPerfSchema  = "ken_perf_samples"
+	pgPerfTables  = 50
+	pgPerfRowsPer = 100
+	pgPerfSampleN = 5
+)
+
+func TestPerf_PostgresSampleRows(t *testing.T) {
+	dsn := os.Getenv("KEN_DB_TEST_DSN")
+	if dsn == "" {
+		t.Skip("set KEN_DB_TEST_DSN; see harness docstring")
+	}
+
+	ctx := context.Background()
+	conn, err := pgx.Connect(ctx, dsn)
+	if err != nil {
+		t.Fatalf("pgx.Connect: %v", err)
+	}
+	defer conn.Close(ctx)
+
+	t.Logf("building fixture: %d tables × %d rows in schema %q...", pgPerfTables, pgPerfRowsPer, pgPerfSchema)
+	buildStart := time.Now()
+	if err := pgPerfBuildFixture(ctx, conn); err != nil {
+		t.Fatalf("fixture: %v", err)
+	}
+	t.Logf("fixture built in %v", time.Since(buildStart))
+	t.Cleanup(func() {
+		_, _ = conn.Exec(ctx, "DROP SCHEMA IF EXISTS "+pgPerfSchema+" CASCADE")
+	})
+
+	// Warm.
+	_ = pgPerfRunSampleLoop(ctx, conn)
+
+	// Per-table timing.
+	t.Log("--- per-table sequential timing ---")
+	perTable, total := pgPerfPerTableTiming(ctx, t, conn)
+	sort.Slice(perTable, func(i, j int) bool { return perTable[i] < perTable[j] })
+	var sum time.Duration
+	for _, d := range perTable {
+		sum += d
+	}
+	mean := sum / time.Duration(len(perTable))
+	t.Logf("per-table sample-query wall: n=%d  min=%v  median=%v  mean=%v  max=%v  sum=%v  total_wall=%v",
+		len(perTable), perTable[0], perTable[len(perTable)/2], mean,
+		perTable[len(perTable)-1], sum, total)
+
+	// Full sampleRowsImpl, 3 trials.
+	t.Log("--- sampleRowsImpl (full function) timing, 3 trials ---")
+	var trials []time.Duration
+	for i := 0; i < 3; i++ {
+		d := pgPerfRunSampleLoop(ctx, conn)
+		trials = append(trials, d)
+		t.Logf("trial %d: %v", i+1, d)
+	}
+	sort.Slice(trials, func(i, j int) bool { return trials[i] < trials[j] })
+	sampleMedian := trials[1]
+	t.Logf("sampleRowsImpl median of 3: %v", sampleMedian)
+
+	// Full introspection (IndexSchema), 3 trials.
+	t.Log("--- full introspection (IndexSchema) timing, 3 trials ---")
+	var fullTrials []time.Duration
+	for i := 0; i < 3; i++ {
+		opts := Options{DSN: dsn, SampleRows: pgPerfSampleN, IncludeSchemas: []string{pgPerfSchema}}
+		s := time.Now()
+		_, err := IndexSchema(ctx, opts)
+		if err != nil {
+			t.Fatalf("IndexSchema: %v", err)
+		}
+		fullTrials = append(fullTrials, time.Since(s))
+	}
+	sort.Slice(fullTrials, func(i, j int) bool { return fullTrials[i] < fullTrials[j] })
+	fullMedian := fullTrials[1]
+	t.Logf("full introspection median: %v", fullMedian)
+	t.Logf("sample-loop fraction of total introspection: %.1f%%",
+		float64(sampleMedian)*100.0/float64(fullMedian))
+
+	t.Log("--- verdict ---")
+	frac := float64(sampleMedian) / float64(fullMedian)
+	switch {
+	case frac < 0.10:
+		t.Logf("sample-loop is <10%% of introspection wall (%.1f%%) — parallelizing it is NOT worth the complexity", frac*100)
+	case frac < 0.30:
+		t.Logf("sample-loop is %.1f%% of introspection wall — borderline", frac*100)
+	default:
+		t.Logf("sample-loop is %.1f%% — parallelizing has real headroom; Amdahl ceiling ≈ %.1fx", frac*100, 1/(1-frac*0.875))
+	}
+}
+
+func pgPerfBuildFixture(ctx context.Context, conn *pgx.Conn) error {
+	if _, err := conn.Exec(ctx, "DROP SCHEMA IF EXISTS "+pgPerfSchema+" CASCADE"); err != nil {
+		return err
+	}
+	if _, err := conn.Exec(ctx, "CREATE SCHEMA "+pgPerfSchema); err != nil {
+		return err
+	}
+	for i := 0; i < pgPerfTables; i++ {
+		var create string
+		switch i % 3 {
+		case 0:
+			create = fmt.Sprintf(
+				"CREATE TABLE %s.t%03d (id INT PRIMARY KEY, label TEXT, payload TEXT)", pgPerfSchema, i)
+		case 1:
+			create = fmt.Sprintf(
+				"CREATE TABLE %s.t%03d (id INT PRIMARY KEY, label VARCHAR(64), updated_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP)", pgPerfSchema, i)
+		case 2:
+			create = fmt.Sprintf(
+				"CREATE TABLE %s.t%03d (id INT PRIMARY KEY, score DOUBLE PRECISION, json_blob JSONB)", pgPerfSchema, i)
+		}
+		if _, err := conn.Exec(ctx, create); err != nil {
+			return fmt.Errorf("create t%03d: %w", i, err)
+		}
+		// Build multi-row insert.
+		var values string
+		for r := 0; r < pgPerfRowsPer; r++ {
+			if r > 0 {
+				values += ", "
+			}
+			switch i % 3 {
+			case 0:
+				values += fmt.Sprintf("(%d, 'label-%d', 'lorem ipsum dolor sit amet payload row %d')", r, r, r)
+			case 1:
+				values += fmt.Sprintf("(%d, 'label-%d', CURRENT_TIMESTAMP)", r, r)
+			case 2:
+				values += fmt.Sprintf(`(%d, %f, '{"k":"v","n":%d}'::jsonb)`, r, float64(r)*1.5, r)
+			}
+		}
+		stmt := fmt.Sprintf("INSERT INTO %s.t%03d VALUES %s", pgPerfSchema, i, values)
+		if _, err := conn.Exec(ctx, stmt); err != nil {
+			return fmt.Errorf("insert t%03d: %w", i, err)
+		}
+		_, _ = conn.Exec(ctx, fmt.Sprintf("ANALYZE %s.t%03d", pgPerfSchema, i))
+	}
+	return nil
+}
+
+func pgPerfRunSampleLoop(ctx context.Context, conn *pgx.Conn) time.Duration {
+	snap := &schemaSnapshot{}
+	for i := 0; i < pgPerfTables; i++ {
+		snap.tables = append(snap.tables, tableInfo{
+			schema: pgPerfSchema,
+			name:   fmt.Sprintf("t%03d", i),
+			columns: []columnInfo{
+				{name: "id", isPrimaryKey: true},
+			},
+		})
+	}
+	opts := Options{SampleRows: pgPerfSampleN, IncludeSchemas: []string{pgPerfSchema}}
+	start := time.Now()
+	sampleRowsImpl(ctx, conn, snap, opts)
+	return time.Since(start)
+}
+
+func pgPerfPerTableTiming(ctx context.Context, t *testing.T, conn *pgx.Conn) ([]time.Duration, time.Duration) {
+	durations := make([]time.Duration, 0, pgPerfTables)
+	totalStart := time.Now()
+	for i := 0; i < pgPerfTables; i++ {
+		name := fmt.Sprintf("t%03d", i)
+		q := fmt.Sprintf(`SELECT * FROM %s."%s" ORDER BY "id" LIMIT $1`, pgPerfSchema, name)
+		s := time.Now()
+		rows, err := conn.Query(ctx, q, pgPerfSampleN)
+		if err != nil {
+			t.Fatalf("sample query %s: %v", name, err)
+		}
+		for rows.Next() {
+			_, _ = rows.Values()
+		}
+		rows.Close()
+		durations = append(durations, time.Since(s))
+	}
+	return durations, time.Since(totalStart)
+}


### PR DESCRIPTION
## Summary

A second-opinion review flagged `mysqlAppendSamples` as an `errgroup` candidate. My initial skepticism (sample `LIMIT 5` over indexed PKs should be cheap) was falsified by measurement, exactly the kind of empirical correction the v0.8.x perf campaign exists to catch.

**MySQL parallelism shipped:**

| metric | post-v0.8.7 (sequential) | post-v0.8.8 (parallel) | Δ |
|---|---|---|---|
| mysqlAppendSamples wall (3-trial median) | 43.7 ms | **19.2 ms** | **2.28× speedup** |
| MySQL full introspection wall | 76.6 ms | **41.4 ms** | **1.85× (92% of Amdahl ceiling)** |

50-table × 100-row Docker-localhost MySQL 8 fixture; M1 Pro / Go 1.26.3. Sample-loop fraction was **57.0% of total introspection wall** — exactly the kind of hotspot the campaign discipline is meant to identify before optimizing.

**Postgres deferred-with-trigger.** `sampleRowsImpl` stays sequential. Postgres' `*pgx.Conn` isn't goroutine-safe, and the architectural alternative — a scoped `pgxpool.Pool` just for the sample pass — was implemented and measured at 22.7 → 21.7 ms (essentially flat) on localhost because pool-setup overhead ate the parallelism gain. Per the v0.8.x discipline ("measured wins only"), reverted; the harness lives in tree as the regression baseline + re-open trigger.

See [ADR-031](https://github.com/townsendmerino/ken/blob/v0.8.8-db-parallelism/docs/DECISIONS.md#adr-031-mysql-introspection-sample-loop-parallelism-postgres-deferred-with-trigger-v088) for the architecture, alternatives considered, and the precursor decisions (rejected Gemini `normalizeMySQLIntType` fast-path; rejected synthetic-latency injection).

## What's in this PR

- **`internal/db/mysql.go`** — `mysqlAppendSamples` wraps per-table sample fetch in `errgroup.WithContext` + `SetLimit(sampleWorkers())`; workers return `nil` unconditionally (preserves `warn+continue`); per-table writes target distinct `&snap.tables[i]` slots so output ordering is preserved by construction. New `sampleWorkers()` helper returns `min(8, runtime.NumCPU())`. `indexSchemaMySQL`'s `*sql.DB` gets `SetMaxOpenConns(sampleWorkers())` so pool size matches worker count.
- **`internal/db/mysql_perf_test.go`** + **`internal/db/postgres_perf_test.go`** — `//go:build dbperf`-gated regression baselines. 50-table × 100-row synthetic fixtures per engine. Both harnesses live in tree even though Postgres isn't parallelized — the Postgres harness IS the re-open trigger for Phase A2-Postgres.
- **`docs/DECISIONS.md`** — ADR-031 inlined; summary-table row added; anchor verified.
- **`docs/PERF.md`** — v0.8.8 closing subsection.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean; `gofmt` clean
- [x] `go test ./...` green (sequential normal-test path unchanged)
- [x] `go test -tags=dbintegration -race -run TestMySQLIntegration ./internal/db/` — all 5 MySQL integration subtests pass `-race`, including the load-bearing `TestMySQLIntegration_RowSamplingDeterministic`
- [x] `go test -tags=dbintegration -race -run TestIntegration ./internal/db/` — Postgres integration unchanged, passes `-race`
- [x] `go test -tags=dbperf -run TestPerf_MySQLAppendSamples -v ./internal/db/` — captures the BEFORE/AFTER data documented in ADR-031
- [x] `go test -tags=dbperf -run TestPerf_PostgresSampleRows -v ./internal/db/` — captures the "wash on localhost" data that motivated the Postgres deferral
- [ ] Second-machine x86_64 confirmation — same outstanding follow-up as v0.8.7's [ADR-029](https://github.com/townsendmerino/ken/blob/main/docs/DECISIONS.md#adr-029-v08x-perf-campaign-capstone--allocationgc-ceiling-reached-indexing-is-single-threaded-parallelism-is-the-next-frontier) commitment; not blocking the merge

## Run the harnesses yourself

```bash
docker run -d --rm --name ken-mysql-perf -p 53306:3306 \
  -e MYSQL_ROOT_PASSWORD=test -e MYSQL_DATABASE=test mysql:8
export KEN_DB_MYSQL_TEST_DSN='root:test@tcp(127.0.0.1:53306)/?parseTime=true'
go test -tags=dbperf -run TestPerf_MySQLAppendSamples -v ./internal/db/

docker run -d --rm --name ken-postgres-perf -p 55432:5432 \
  -e POSTGRES_PASSWORD=test postgres:16-alpine
export KEN_DB_TEST_DSN='postgres://postgres:test@127.0.0.1:55432/postgres?sslmode=disable'
go test -tags=dbperf -run TestPerf_PostgresSampleRows -v ./internal/db/
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)