### PR TITLE
feat(treesitter): per-reason fallback counters + ken perf index JSON surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,16 @@ with pre-built binaries.
 
 ## [Unreleased]
 
-(no changes yet)
+### Added (treesitter chunker fallback observability)
+
+- **Per-reason fallback counters on the treesitter chunker.** `internal/chunk/treesitter.Chunker` now tracks four atomic counters — one per silent-fallback site in `Chunk` (unsupported language, `pool.Parse` error, nil root node, invalid spans) — plus a total-files-attempted counter. Exposed via `Chunker.Stats() Stats`. Thread-safe (`sync/atomic`); negligible hot-path cost (one atomic add per chunked file).
+- **`treesitter` field on `ken perf index` JSON output (omitempty).** When `--chunker=treesitter`, the perf record includes a `treesitter` object with `total`, `fallback`, and per-reason counts. Lets callers — primarily the OSS-demo build-time validation per `outputs/oss-demo-playbook.md` — quantify how many files in a corpus actually got AST-chunked vs silently degraded to the line chunker.
+
+### Calibration discipline
+
+This is **observability only**: a measurement gap closed. **NOT** a retrieval-quality change, **NOT** a recall change, **NOT** a search-ranking change, **NOT** a behavior change. The silent-fallback semantics ADR-010 chose are deliberately preserved — `ken index` / `ken-mcp` / library callers see byte-identical output and zero new stderr spam. The counters are introspection for callers who explicitly want them (`perf index`'s JSON consumer); every other caller is unaffected.
+
+Same calibration framing as v0.8.3's "cold-start optimization, NOT search-quality change" and v0.8.1's "Tier-1 chunk fidelity, NOT recall" entries.
 
 ## [0.8.3] — 2026-05-26
 

--- a/cmd/ken/perf.go
+++ b/cmd/ken/perf.go
@@ -29,6 +29,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/townsendmerino/ken/internal/chunk"
+	"github.com/townsendmerino/ken/internal/chunk/treesitter"
 	"github.com/townsendmerino/ken/internal/perf"
 	"github.com/townsendmerino/ken/internal/search"
 )
@@ -102,13 +104,22 @@ land at the --cpuprofile / --memprofile paths. Sibling to 'ken bench'
 }
 
 // perfIndexRecord is the JSON shape `ken perf index` writes to stdout.
+//
+// TreesitterStats is populated only when `--chunker=treesitter` was
+// selected for the run; for any other chunker it stays nil and the
+// `treesitter` field is omitted from the JSON output (preserving
+// byte-identical records for regex / line runs). The counters live on
+// the treesitter Chunker singleton registered in the chunk registry, so
+// reading them after FromFS returns gives the per-reason fallback
+// breakdown for this specific build.
 type perfIndexRecord struct {
-	IndexMs      float64         `json:"index_ms"`
-	Chunks       int             `json:"chunks"`
-	BytesIndexed int             `json:"bytes_indexed"`
-	AllocDelta   perf.AllocDelta `json:"alloc_delta"`
-	Heap         perf.HeapStats  `json:"heap"`
-	perfMeta                     // embedded; flattened into the JSON record
+	IndexMs         float64           `json:"index_ms"`
+	Chunks          int               `json:"chunks"`
+	BytesIndexed    int               `json:"bytes_indexed"`
+	AllocDelta      perf.AllocDelta   `json:"alloc_delta"`
+	Heap            perf.HeapStats    `json:"heap"`
+	TreesitterStats *treesitter.Stats `json:"treesitter,omitempty"`
+	perfMeta                          // embedded; flattened into the JSON record
 }
 
 func cmdPerfIndex(args []string) int {
@@ -197,6 +208,21 @@ func cmdPerfIndex(args []string) int {
 		AllocDelta:   allocDelta,
 		Heap:         heap,
 		perfMeta:     buildMeta(modeStr, chunker, model),
+	}
+	// Capture treesitter fallback stats only when this run used the
+	// treesitter chunker. Reading the registry-resident singleton's
+	// counters here (after FromFS returns) yields the per-reason
+	// breakdown of how many files this build actually AST-chunked vs
+	// silently degraded to the line chunker. Used by the OSS-demo
+	// playbook to validate the AST-quality premise per-corpus before
+	// committing a treesitter chunker choice.
+	if chunker == "treesitter" {
+		if ch, err := chunk.Get("treesitter"); err == nil {
+			if ts, ok := ch.(*treesitter.Chunker); ok {
+				stats := ts.Stats()
+				rec.TreesitterStats = &stats
+			}
+		}
 	}
 	if err := json.NewEncoder(os.Stdout).Encode(rec); err != nil {
 		fmt.Fprintln(os.Stderr, "ken: "+err.Error())

--- a/internal/chunk/treesitter/chunker.go
+++ b/internal/chunk/treesitter/chunker.go
@@ -58,6 +58,7 @@ package treesitter
 
 import (
 	"sync"
+	"sync/atomic"
 
 	"github.com/odvcencio/gotreesitter"
 	"github.com/odvcencio/gotreesitter/grammars"
@@ -83,6 +84,59 @@ type Chunker struct {
 	lineOnce     sync.Once
 	lineCh       chunk.Chunker
 	lineLookupOK bool
+
+	// Per-reason fallback counters. Atomic-incremented at each of the
+	// four silent-fallback sites in Chunk so callers (`ken perf index`,
+	// the OSS-demo build-time validation per outputs/oss-demo-playbook.md)
+	// can quantify how many files actually got AST chunks vs degraded to
+	// the line chunker. Exposed via Stats(); zero allocations on the hot
+	// path. ADR-010 graceful-degradation behavior is unchanged.
+	total           atomic.Int64
+	unsupportedLang atomic.Int64
+	parseErr        atomic.Int64
+	nilRoot         atomic.Int64
+	invalidSpans    atomic.Int64
+}
+
+// Stats is a point-in-time snapshot of the treesitter chunker's
+// per-reason fallback counters since process start (or since the
+// Chunker was constructed). Read via Chunker.Stats(). Concurrency-safe:
+// each field is loaded with an atomic.Load, so the snapshot is
+// internally consistent for each counter but the four counters are not
+// captured atomically as a group — a few sub-microsecond skew across
+// fields is possible when reading mid-indexing. For the OSS-demo
+// validation use case (read once after FromFS returns), the snapshot
+// is point-stable.
+//
+// Fallback is the sum of the four per-reason counters and is what the
+// demo decision wants: "of the files we tried to AST-chunk, how many
+// silently degraded to line-chunking?"
+type Stats struct {
+	Total           int64 `json:"total"`
+	Fallback        int64 `json:"fallback"`
+	UnsupportedLang int64 `json:"unsupported_lang"`
+	ParseErr        int64 `json:"parse_err"`
+	NilRoot         int64 `json:"nil_root"`
+	InvalidSpans    int64 `json:"invalid_spans"`
+}
+
+// Stats returns a point-in-time snapshot of the chunker's per-reason
+// fallback counters. Safe to call from any goroutine while indexing is
+// in progress; safe to call multiple times (counters keep accumulating
+// across calls, so two snapshots N and N+1 let you compute a delta).
+func (c *Chunker) Stats() Stats {
+	unsupportedLang := c.unsupportedLang.Load()
+	parseErr := c.parseErr.Load()
+	nilRoot := c.nilRoot.Load()
+	invalidSpans := c.invalidSpans.Load()
+	return Stats{
+		Total:           c.total.Load(),
+		Fallback:        unsupportedLang + parseErr + nilRoot + invalidSpans,
+		UnsupportedLang: unsupportedLang,
+		ParseErr:        parseErr,
+		NilRoot:         nilRoot,
+		InvalidSpans:    invalidSpans,
+	}
 }
 
 // New returns a tree-sitter chunker. The internal caches are empty;
@@ -188,11 +242,17 @@ func (c *Chunker) Chunk(source []byte, language string, chunkSize int) ([]chunk.
 	if chunkSize <= 0 {
 		chunkSize = chunk.DefaultChunkSize
 	}
+	// Count this call as one "file attempted" for the Stats snapshot.
+	// The atomic add is negligible relative to parse cost; placing it
+	// after the len==0 guard so empty sources (which return nil chunks
+	// without doing any parsing) aren't included in the denominator.
+	c.total.Add(1)
 
 	pool := c.poolFor(language)
 	if pool == nil {
 		// Language unsupported or grammar unavailable. Degrade to
 		// the line chunker rather than emit a single whole-file chunk.
+		c.unsupportedLang.Add(1)
 		return c.fallback(source, language, chunkSize)
 	}
 
@@ -201,10 +261,12 @@ func (c *Chunker) Chunk(source []byte, language string, chunkSize int) ([]chunk.
 		// Parse errors here are tree-sitter's "I gave up" — typically
 		// a timeout firing on a pathological input. Fall back to the
 		// line chunker so the file still produces useful BM25 docs.
+		c.parseErr.Add(1)
 		return c.fallback(source, language, chunkSize)
 	}
 	root := tree.RootNode()
 	if root == nil {
+		c.nilRoot.Add(1)
 		return c.fallback(source, language, chunkSize)
 	}
 
@@ -216,6 +278,7 @@ func (c *Chunker) Chunk(source []byte, language string, chunkSize int) ([]chunk.
 	// start bytes aren't monotonic. If anything still looks wrong, fall
 	// back to the line chunker rather than panic in the slice op below.
 	if !spansValid(spans, uint32(len(source))) {
+		c.invalidSpans.Add(1)
 		return c.fallback(source, language, chunkSize)
 	}
 	out := make([]chunk.Chunk, len(spans))

--- a/internal/chunk/treesitter/stats_test.go
+++ b/internal/chunk/treesitter/stats_test.go
@@ -1,0 +1,90 @@
+package treesitter
+
+import (
+	"testing"
+)
+
+// TestStats_UnsupportedLanguageIncrementsFallback exercises the
+// language-not-in-kenToTreeSitter branch of Chunk — the silent
+// fallback path the OSS-demo playbook needs to be able to quantify.
+// Asserts that:
+//
+//   - Total counts every non-empty source we attempted to chunk.
+//   - UnsupportedLang increments for each call routed to the line
+//     chunker via "no grammar for this language" (vs the
+//     pool.Parse-error / nil-root / invalid-spans branches, which
+//     this test doesn't try to trigger because they're hard to
+//     construct deterministically without grammar-internal knowledge).
+//   - Fallback equals the sum of the per-reason counters.
+//   - The empty-source early return does NOT count toward Total
+//     (no parse attempted).
+func TestStats_UnsupportedLanguageIncrementsFallback(t *testing.T) {
+	c := New()
+
+	// Pick a language name guaranteed to miss kenToTreeSitter so we
+	// hit poolFor()==nil. "csharp" is deliberately omitted from
+	// kenToTreeSitter per chunker.go's documented language list (the
+	// grammar OOMs on real C# content); "qbasic" would also work as
+	// a never-was-supported sentinel.
+	const bogus = "qbasic-never-supported"
+	chunks, err := c.Chunk([]byte("PRINT \"HELLO\"\n"), bogus, 1024)
+	if err != nil {
+		t.Fatalf("Chunk(unsupported lang) returned err: %v", err)
+	}
+	if len(chunks) == 0 {
+		t.Fatalf("expected line-fallback to produce at least one chunk; got 0")
+	}
+	stats := c.Stats()
+	if stats.Total != 1 {
+		t.Errorf("Total = %d, want 1 (one non-empty source attempted)", stats.Total)
+	}
+	if stats.UnsupportedLang != 1 {
+		t.Errorf("UnsupportedLang = %d, want 1", stats.UnsupportedLang)
+	}
+	if stats.Fallback != 1 {
+		t.Errorf("Fallback = %d, want 1 (sum of per-reason counters)", stats.Fallback)
+	}
+
+	// Second unsupported-lang call: counters accumulate, not reset.
+	_, _ = c.Chunk([]byte("X = 1\n"), bogus, 1024)
+	stats = c.Stats()
+	if stats.Total != 2 || stats.UnsupportedLang != 2 || stats.Fallback != 2 {
+		t.Errorf("after 2 calls: Total=%d UnsupportedLang=%d Fallback=%d; want 2,2,2",
+			stats.Total, stats.UnsupportedLang, stats.Fallback)
+	}
+
+	// Empty-source path is the documented short-circuit in Chunk
+	// (returns (nil, nil) before any counter increment). Verify Total
+	// is NOT bumped — otherwise the fallback rate the playbook reads
+	// would be diluted by every empty file the walker happens to surface.
+	_, _ = c.Chunk(nil, bogus, 1024)
+	_, _ = c.Chunk([]byte{}, bogus, 1024)
+	stats = c.Stats()
+	if stats.Total != 2 {
+		t.Errorf("empty-source calls should not bump Total; got %d, want 2", stats.Total)
+	}
+
+	// A supported language with valid input should NOT increment any
+	// fallback counter — Total bumps, fallback counters don't. Uses
+	// "go" because the existing TestByteFidelity proves it parses
+	// cleanly through to a real cAST result.
+	const goSrc = `package x
+
+func F() int { return 1 }
+`
+	_, err = c.Chunk([]byte(goSrc), "go", 1024)
+	if err != nil {
+		t.Fatalf("Chunk(go) returned err: %v", err)
+	}
+	stats = c.Stats()
+	if stats.Total != 3 {
+		t.Errorf("after supported-lang call: Total=%d, want 3", stats.Total)
+	}
+	if stats.Fallback != 2 {
+		t.Errorf("supported-lang call should not increment Fallback; got %d, want 2 (carry from earlier)", stats.Fallback)
+	}
+	if stats.ParseErr != 0 || stats.NilRoot != 0 || stats.InvalidSpans != 0 {
+		t.Errorf("unexpected non-zero per-reason counter: ParseErr=%d NilRoot=%d InvalidSpans=%d",
+			stats.ParseErr, stats.NilRoot, stats.InvalidSpans)
+	}
+}


### PR DESCRIPTION
## Summary

The treesitter chunker's four silent-fallback sites in `Chunk` (unsupported language, `pool.Parse` error, nil root, invalid spans) all route through `c.fallback()` with zero logging — [ADR-010](https://github.com/townsendmerino/ken/blob/main/docs/DECISIONS.md#adr-010-tree-sitter-via-gotreesitter-instead-of-wazerowasm)'s deliberate graceful-degrade behavior. That's the right default for `ken index` / `ken-mcp`, but it left the OSS-demo playbook (`outputs/oss-demo-playbook.md`) unable to validate the treesitter-for-postgres premise: of the `.c`/`.h` files we ship treesitter for, how many actually got AST chunks vs silently line-fell-back?

**Closes the measurement gap by adding observability ONLY. Silent fallback semantics unchanged.**

## Empirical validation

Ran the new counters against the actual demo corpora (M1 Pro / arm64 / commit 0034c93 + this change / kubernetes vendor pruned per playbook):

| corpus | files routed to treesitter | fallback | rate |
|---|---|---|---|
| **postgres** | 2,383 | **0** | **0.00%** |
| **kubernetes** | 10,764 | **0** | **0.00%** |

**The treesitter-for-postgres premise holds.** Every single file the treesitter chunker tried on postgres produced real AST chunks via cAST — zero silent line-fallback. The earlier interpretation that "the 5.5% chunk-count gap between regex (line-fallback) and treesitter on postgres might be silent fallback" is falsified — it's actually "AST chunks happen to average close in size to the 50-line line-chunker default on postgres C code."

Cross-check of the `total` counter against actual file counts:
- postgres has 2,378 `.c`/`.h` files + 5 other treesitter-eligible files = **2,383** → matches `total: 2,383` exactly
- kubernetes has 10,755 `.go` files → `total: 10,764` (within 9, likely scattered `.py`/`.ts`)

## Changes

- **`internal/chunk/treesitter.Chunker`** — four `atomic.Int64` per-reason counters (`UnsupportedLang` / `ParseErr` / `NilRoot` / `InvalidSpans`) plus a `Total` files-attempted counter. `Stats()` returns a snapshot with `Fallback` computed as the sum of per-reason counts. Thread-safe — the registered `Chunker` singleton is shared across v0.8.7's parallel per-file indexing goroutines and the `chunk.Chunker` contract promises goroutine-safety. Hot-path cost: one atomic add per chunked file (negligible vs parse cost).
- **`cmd/ken/perf.go`** — `perfIndexRecord` gains `TreesitterStats *treesitter.Stats` with `omitempty`. Populated only when `--chunker=treesitter` so regex/line runs produce byte-identical JSON to before. Captured after `FromFS` returns via `chunk.Get("treesitter")` + type-assert to `*treesitter.Chunker`.
- **`internal/chunk/treesitter/stats_test.go`** — minimal regression net. Asserts `Total` / `UnsupportedLang` / `Fallback` increment correctly for unsupported-language calls, accumulate across calls, are NOT bumped by empty-source early-return, and stay zero on a supported-language call.
- **`CHANGELOG.md`** — Unreleased entry, calibrated as "observability only, NOT a retrieval-quality / recall / ranking change" per the v0.8.3-style framing.

## Calibration discipline

**Observability only.** NOT a retrieval-quality change, NOT a recall change, NOT a search-ranking change, NOT a behavior change. ADR-010's silent-fallback semantics are deliberately preserved — `ken index` / `ken-mcp` / library callers see byte-identical output and zero new stderr output. The counters are introspection for callers who explicitly want them (`perf index`'s JSON consumer); every other caller is unaffected.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean, `gofmt` clean
- [x] `go test ./...` green
- [x] `go test -race ./internal/chunk/treesitter/` green
- [x] `TestStats_UnsupportedLanguageIncrementsFallback` passes (the new regression net)
- [x] Empirical end-to-end re-measurement: postgres 0/2,383 fallback, kubernetes 0/10,764 fallback (numbers above)
- [x] `--chunker=regex` and `--chunker=line` perf runs produce byte-identical JSON to before (the new `treesitter` field is `omitempty`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)