### PR TITLE
feat(ken-mcp): auto-load pre-built index <repo>/.ken/index.bin (cold-start fix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ with pre-built binaries.
 
 ## [Unreleased]
 
+### Added (ken-mcp pre-built-index cold-start)
+
+- **`ken-mcp` auto-loads a pre-built index at `<repo>/.ken/index.bin`.** The standalone `ken-mcp` binary now honors the same ADR-024 convention `mcp.Run` already did: when a corpus carries a pre-built index (from `ken build-index <repo> -o <repo>/.ken/index.bin`), the server loads it in ~1-2 s and serves it **frozen, with no file watcher** — instead of paying a full live walk+chunk+embed build on the first query. Repos without a baked index are unchanged (lazy live build + watcher, exactly as before).
+- **Eager startup validation for the default repo.** When `KEN_MCP_DEFAULT_REPO` points at a local path carrying `.ken/index.bin`, the index is loaded + validated at startup (warming the cache so the first query is instant). A **mode/chunker mismatch** between the pre-built index and the server's `KEN_MCP_MODE` / `KEN_MCP_CHUNKER` is a **hard startup failure** (exit 1) with a message naming both sides and the fix — we won't silently serve wrong-config results. Corrupt / incompatible-format / missing-model pre-built files **warn and fall back** to a live build (a slower-but-correct result beats an outage).
+
+  Motivation: a postgres+treesitter `ken-mcp` server hung on its first query during demo capture — three consecutive MCP `search` calls timed out at ~4 min and the server went unresponsive. Measured root cause (not the initially-suspected single-flight or watch-mode overhead — both were ruled out by reproduction): the binary always **live-indexes** the default repo on first query, and a treesitter build of postgres is ~44 s on a quiet machine. Under capture-time contention (three ken-mcp servers + the app on a 16 GB box) that 44 s exceeded the MCP client's tool-call timeout. Loading a pre-built index removes the build from the request path: measured **first cold `search` 44.6 s → 46.6 ms** on postgres+treesitter (real binary, `sdk.CommandTransport`).
+
+### Calibration discipline (cold-start)
+
+**Startup/transport only — NOT a retrieval-quality, recall, or ranking change, and NOT a change to what gets indexed.** A loaded pre-built index serves byte-identical chunks to what `ken build-index` produced for the same corpus + flags, so transcripts captured against a live index and against the pre-built index reflect the same retrieval. Single-flight (already present in `mcp/cache.go`) and watch-mode were both verified by reproduction to be working/irrelevant; no behavior changed there. Same framing as v0.8.3's "cold-start optimization, NOT search-quality change."
+
 ### Added (treesitter chunker fallback observability)
 
 - **Per-reason fallback counters on the treesitter chunker.** `internal/chunk/treesitter.Chunker` now tracks four atomic counters — one per silent-fallback site in `Chunk` (unsupported language, `pool.Parse` error, nil root node, invalid spans) — plus a total-files-attempted counter. Exposed via `Chunker.Stats() Stats`. Thread-safe (`sync/atomic`); negligible hot-path cost (one atomic add per chunked file).

--- a/cmd/ken-mcp/loadorbuild_test.go
+++ b/cmd/ken-mcp/loadorbuild_test.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/townsendmerino/ken/internal/search"
+	kenmcp "github.com/townsendmerino/ken/mcp"
+
+	_ "github.com/townsendmerino/ken/internal/chunk/regex"
+)
+
+// writeCorpus lays down a tiny bm25-indexable corpus and returns its dir.
+func writeCorpus(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "a.go"),
+		[]byte("package x\n\nfunc Alpha() int { return 1 }\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+// bakePrebuilt builds a bm25 index for dir with the given chunker and
+// writes it to <dir>/.ken/index.bin (the ADR-024 convention).
+func bakePrebuilt(t *testing.T, dir, chunker string) {
+	t.Helper()
+	data, err := search.BuildAndSerializeIndex(os.DirFS(dir), search.BuildOptions{
+		Mode:    search.ModeBM25,
+		Chunker: chunker,
+	})
+	if err != nil {
+		t.Fatalf("BuildAndSerializeIndex: %v", err)
+	}
+	kenDir := filepath.Join(dir, ".ken")
+	if err := os.MkdirAll(kenDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(kenDir, "index.bin"), data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func quietLogger() *kenmcp.Logger { return kenmcp.NewLogger(os.Stderr, kenmcp.LogError) }
+
+// No pre-built index → live build with the watcher (original behavior).
+func TestLoadOrBuild_NoPrebuilt_LiveBuilds(t *testing.T) {
+	dir := writeCorpus(t)
+	wi, err := loadOrBuildWatched(dir, search.ModeBM25, "bm25", "regex", "", search.FSOptions{}, quietLogger())
+	if err != nil {
+		t.Fatalf("loadOrBuildWatched: %v", err)
+	}
+	defer wi.Close()
+	if wi.Len() == 0 {
+		t.Errorf("live build produced an empty index")
+	}
+}
+
+// Pre-built index present + matching chunker → static load (no watcher).
+func TestLoadOrBuild_Prebuilt_Matching_Loads(t *testing.T) {
+	dir := writeCorpus(t)
+	bakePrebuilt(t, dir, "regex")
+	wi, err := loadOrBuildWatched(dir, search.ModeBM25, "bm25", "regex", "", search.FSOptions{}, quietLogger())
+	if err != nil {
+		t.Fatalf("loadOrBuildWatched: %v", err)
+	}
+	defer wi.Close()
+	if wi.Len() == 0 {
+		t.Errorf("loaded pre-built index is empty")
+	}
+}
+
+// Pre-built index present but chunker mismatches the server config →
+// hard error (the operator must fix it; we won't serve wrong-config
+// results). This is the failure main() turns into a startup exit(1).
+func TestLoadOrBuild_Prebuilt_ChunkerMismatch_Errors(t *testing.T) {
+	dir := writeCorpus(t)
+	bakePrebuilt(t, dir, "regex") // index built with regex...
+	// ...server configured for treesitter.
+	_, err := loadOrBuildWatched(dir, search.ModeBM25, "bm25", "treesitter", "", search.FSOptions{}, quietLogger())
+	if err == nil {
+		t.Fatal("expected a hard error on chunker mismatch, got nil")
+	}
+	if !errors.Is(err, search.ErrChunkerMismatch) {
+		t.Errorf("error chain should include ErrChunkerMismatch; got %v", err)
+	}
+	if !strings.Contains(err.Error(), "index.bin") {
+		t.Errorf("error should name the offending file; got %v", err)
+	}
+}
+
+// localPathHasPrebuilt: true only for a local dir carrying .ken/index.bin.
+func TestLocalPathHasPrebuilt(t *testing.T) {
+	dir := writeCorpus(t)
+	if localPathHasPrebuilt(dir) {
+		t.Error("no .ken/index.bin yet → want false")
+	}
+	bakePrebuilt(t, dir, "regex")
+	if !localPathHasPrebuilt(dir) {
+		t.Error("after baking index.bin → want true")
+	}
+	if localPathHasPrebuilt("https://github.com/townsendmerino/ken") {
+		t.Error("http(s) sources never have a local pre-built → want false")
+	}
+}

--- a/cmd/ken-mcp/main.go
+++ b/cmd/ken-mcp/main.go
@@ -22,6 +22,8 @@ package main
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"io"
 	"log"
 	"net/url"
@@ -35,6 +37,7 @@ import (
 	sdkmcp "github.com/modelcontextprotocol/go-sdk/mcp"
 
 	"github.com/townsendmerino/ken/internal/chunk"
+	"github.com/townsendmerino/ken/internal/embed"
 	// Side-effect imports: register every chunker the stock binary
 	// offers. internal/search blank-imports "regex" (the default), so
 	// we only need the optional chunkers here. The treesitter import
@@ -64,6 +67,93 @@ func modelAvailable(dir string) bool {
 	}
 	_, err := os.Stat(filepath.Join(dir, "model.safetensors"))
 	return err == nil
+}
+
+// prebuiltIndexPath is the ADR-024 convention for a pre-built index
+// baked next to a corpus: <dir>/.ken/index.bin. The walker prunes .ken/
+// so the file is never re-indexed into the corpus.
+func prebuiltIndexPath(dir string) string {
+	return filepath.Join(dir, ".ken", "index.bin")
+}
+
+// localPathHasPrebuilt reports whether dir is a local path carrying a
+// pre-built index at the conventional location. http(s) sources never
+// have one (they're shallow-cloned to a temp dir at request time).
+func localPathHasPrebuilt(dir string) bool {
+	if strings.HasPrefix(dir, "http://") || strings.HasPrefix(dir, "https://") {
+		return false
+	}
+	_, err := os.Stat(prebuiltIndexPath(dir))
+	return err == nil
+}
+
+// loadOrBuildWatched returns a WatchedIndex for dir, preferring a
+// pre-built <dir>/.ken/index.bin (ADR-024) over a live walk+chunk+embed
+// build. The pre-built path loads in ~1-2s and serves a frozen,
+// non-watching snapshot — the demo-appropriate shape (the OSS-demo
+// playbook mandates "never run watch-mode in the demo"), and the fix
+// for the cold-start blocker where a 44s treesitter build exceeded the
+// MCP client's tool-call timeout.
+//
+// Precedence + failure handling:
+//   - No pre-built file → live-index with the file watcher (unchanged
+//     v0.3+ behavior). Repos without a baked index keep working exactly
+//     as before.
+//   - Pre-built present, mode/chunker MISMATCH → hard error. The
+//     operator built the index with different `ken build-index` flags
+//     than the server's KEN_MCP_MODE/KEN_MCP_CHUNKER; serving it would
+//     silently return wrong-config results. The default-repo path turns
+//     this into a startup exit (see main); ad-hoc repo args surface it
+//     as a failed tool call.
+//   - Pre-built present, corrupt / incompatible format / missing model →
+//     warn and fall back to a live build. The file is unusable but the
+//     corpus is still indexable; a slower-but-correct result beats an
+//     outage. (Distinct from mismatch, which is a config error the
+//     operator must fix.)
+func loadOrBuildWatched(dir string, mode search.Mode, modeStr, chunker, modelDir string, fsOpts search.FSOptions, logger *kenmcp.Logger) (*search.WatchedIndex, error) {
+	if data, err := os.ReadFile(prebuiltIndexPath(dir)); err == nil {
+		var model *embed.StaticModel
+		if mode != search.ModeBM25 {
+			m, mErr := embed.LoadFromFS(os.DirFS(modelDir), ".")
+			if mErr != nil {
+				logger.Logf(kenmcp.LogWarn, "pre-built index %s needs a model but loading %q failed (%v); live-indexing instead",
+					prebuiltIndexPath(dir), modelDir, mErr)
+				return liveWatched(dir, mode, chunker, modelDir, fsOpts, logger)
+			}
+			model = m
+		}
+		ix, lErr := search.LoadSerializedIndex(data, search.LoadOptions{
+			ExpectedMode:    modeStr,
+			ExpectedChunker: chunker,
+			Model:           model,
+		})
+		switch {
+		case lErr == nil:
+			logger.Logf(kenmcp.LogInfo, "loaded pre-built index %s (%d chunks, no watch)", prebuiltIndexPath(dir), ix.Len())
+			return search.WrapStatic(ix, dir, mode, chunker), nil
+		case errors.Is(lErr, search.ErrModeMismatch) || errors.Is(lErr, search.ErrChunkerMismatch):
+			// Config error — fail loud rather than serve wrong results.
+			return nil, fmt.Errorf("pre-built index %s: %w (server is mode=%s chunker=%s; rebuild with matching `ken build-index` flags or fix KEN_MCP_MODE/KEN_MCP_CHUNKER)",
+				prebuiltIndexPath(dir), lErr, modeStr, chunker)
+		default:
+			// Corrupt / format-version / model-required — fall back.
+			logger.Logf(kenmcp.LogWarn, "pre-built index %s unusable (%v); live-indexing instead", prebuiltIndexPath(dir), lErr)
+		}
+	}
+	return liveWatched(dir, mode, chunker, modelDir, fsOpts, logger)
+}
+
+// liveWatched is the original walk+chunk+embed build with the file
+// watcher enabled (v0.3+ behavior). Factored out so loadOrBuildWatched
+// has a single fallback call site.
+func liveWatched(dir string, mode search.Mode, chunker, modelDir string, fsOpts search.FSOptions, logger *kenmcp.Logger) (*search.WatchedIndex, error) {
+	logger.Logf(kenmcp.LogInfo, "indexing %s (live build, watching)", dir)
+	ix, err := search.NewWatchedIndexWithOptions(dir, mode, chunker, modelDir, true, fsOpts)
+	if err != nil {
+		return nil, err
+	}
+	logger.Logf(kenmcp.LogInfo, "indexed %s (%d chunks, watching)", dir, ix.Len())
+	return ix, nil
 }
 
 // runSubcommand dispatches one-shot CLI subcommands that exit before
@@ -148,11 +238,13 @@ func main() {
 	// in-place. mcp.NormalizeKey hands us either a canonical URL or an
 	// absolute path — we discriminate on the scheme prefix here.
 	//
-	// v0.3: returns *search.WatchedIndex. ken-mcp always watches (the
-	// in-process LRU otherwise serves stale results when an agent
-	// edits files mid-session). The cache calls wix.Close() before
-	// invoking the user cleanup, so the watcher's inotify fds drop
-	// before the temp clone dir is rm-rf'd.
+	// v0.3: returns *search.WatchedIndex. A live build watches (the
+	// in-process LRU otherwise serves stale results when an agent edits
+	// files mid-session); a pre-built index (ADR-024, <dir>/.ken/index.bin)
+	// is served frozen with no watcher via loadOrBuildWatched. The cache
+	// calls wix.Close() before invoking the user cleanup, so a live
+	// build's watcher fds drop before the temp clone dir is rm-rf'd
+	// (Close() is a no-op for the static pre-built case).
 	builder := func(ctx context.Context, source string) (*search.WatchedIndex, func(), error) {
 		var dir string
 		var cleanup func()
@@ -166,12 +258,11 @@ func main() {
 		} else {
 			dir = source
 		}
-		logger.Logf(kenmcp.LogInfo, "indexing %s (mode=%s)", dir, modeStr)
 		fsOpts := search.FSOptions{
 			DisableFoldMigrations: noAutoMigrations,
 			LogWriter:             os.Stderr,
 		}
-		ix, err := search.NewWatchedIndexWithOptions(dir, mode, chunker, modelDir, true, fsOpts)
+		ix, err := loadOrBuildWatched(dir, mode, modeStr, chunker, modelDir, fsOpts, logger)
 		if err != nil {
 			if cleanup != nil {
 				cleanup()
@@ -185,11 +276,24 @@ func main() {
 		ix.SetOnFlush(func(msg string) {
 			logger.Logf(kenmcp.LogInfo, "%s: %s", dir, msg)
 		})
-		logger.Logf(kenmcp.LogInfo, "indexed %s (%d chunks, watching)", dir, ix.Len())
 		return ix, cleanup, nil
 	}
 
 	cache := kenmcp.NewCache(size, builder)
+
+	// Eager pre-built-index validation for the default repo. If the
+	// operator placed a <repo>/.ken/index.bin, we want a mode/chunker
+	// mismatch to fail LOUDLY at startup (not silently fall back to a
+	// 44s live build on the first query, nor serve wrong-config results).
+	// Only fires when a pre-built file exists — repos without one stay
+	// fully lazy (no startup build cost). A successful eager Get also
+	// warms the cache so the first real query is instant.
+	if defaultRepo != "" && localPathHasPrebuilt(defaultRepo) {
+		if _, err := cache.Get(context.Background(), defaultRepo); err != nil {
+			logger.Logf(kenmcp.LogError, "default repo pre-built index unusable: %v", err)
+			os.Exit(1)
+		}
+	}
 
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()

--- a/internal/search/watch.go
+++ b/internal/search/watch.go
@@ -122,6 +122,38 @@ type WatchedIndex struct {
 	// or an existing one no longer qualifies). On a flush touching any
 	// file in one of these dirs, the WHOLE dir is re-folded.
 	migrationDirs map[string]bool
+
+	// static marks a WatchedIndex created by WrapStatic — a frozen
+	// pre-built index (ADR-024) with no watcher and no live corpus
+	// (chunks/vecs/model are empty because the index was loaded from
+	// serialized bytes, not built from a walk). SetExtraChunks guards
+	// on this so the DB-Tier-2 union-rebuild path can't replace the
+	// loaded snapshot with one built from an empty corpus.
+	static bool
+}
+
+// WrapStatic wraps an already-built *Index (typically from
+// LoadSerializedIndex — ADR-024's pre-built-index path) in a
+// WatchedIndex that never watches, never re-publishes, and owns no
+// fsnotify state. This is the cache.Builder-compatible shape for serving
+// a frozen on-disk index: the ken-mcp binary loads <corpus>/.ken/index.bin
+// in ~1-2s instead of paying the full walk+chunk+embed build, and the
+// frozen index is exactly the demo-appropriate behavior (no watcher).
+//
+// Close() is a no-op (done is pre-closed; there's no goroutine to stop).
+// SetExtraChunks is a guarded no-op (see its doc) because a static index
+// has no live corpus to union against.
+func WrapStatic(ix *Index, root string, mode Mode, chunkerName string) *WatchedIndex {
+	wi := &WatchedIndex{
+		root:        root,
+		mode:        mode,
+		chunkerName: chunkerName,
+		done:        make(chan struct{}),
+		static:      true,
+	}
+	wi.ix.Store(ix)
+	close(wi.done) // no watcher goroutine; Close()'s <-w.done returns immediately
+	return wi
 }
 
 // NewWatchedIndex builds the initial snapshot via FromPath, then (if
@@ -482,6 +514,17 @@ func (w *WatchedIndex) buildUnionedIndexLocked() *Index {
 // acceptable — DB refreshes are infrequent (startup, periodic ≥1m,
 // SIGHUP) and embedding cost is bounded by chunk count.
 func (w *WatchedIndex) SetExtraChunks(chunks []chunk.Chunk) {
+	// A static (pre-built) index has no live corpus in w.chunks/w.vecs —
+	// the snapshot was loaded from serialized bytes. buildUnionedIndexLocked
+	// would rebuild from an empty corpus ∪ extras, silently dropping the
+	// entire loaded index. Guard against that: pre-built + DB-Tier-2 is an
+	// unsupported combination (bake DB chunks in at `ken build-index` time
+	// instead), so the right behavior is to keep serving the loaded index
+	// and ignore the extras rather than corrupt the snapshot.
+	if w.static {
+		return
+	}
+
 	w.corpusMu.Lock()
 	defer w.corpusMu.Unlock()
 

--- a/internal/search/wrapstatic_test.go
+++ b/internal/search/wrapstatic_test.go
@@ -1,0 +1,52 @@
+package search
+
+import (
+	"testing"
+
+	"github.com/townsendmerino/ken/internal/chunk"
+)
+
+// TestWrapStatic covers the pre-built-index wrapper used by the ken-mcp
+// binary: a frozen *Index served through the WatchedIndex shape with no
+// watcher goroutine. Verifies reads work, Close is a non-blocking no-op,
+// and the SetExtraChunks guard preserves the loaded snapshot instead of
+// rebuilding from an empty corpus.
+func TestWrapStatic(t *testing.T) {
+	chunks := []chunk.Chunk{
+		{File: "a.go", StartLine: 1, EndLine: 3, Text: "func Alpha() {}\n"},
+		{File: "b.go", StartLine: 1, EndLine: 3, Text: "func Bravo() {}\n"},
+	}
+	ix := BuildIndex(chunks, nil, ModeBM25, nil)
+
+	wi := WrapStatic(ix, "/some/corpus", ModeBM25, "treesitter")
+
+	if got := wi.Len(); got != 2 {
+		t.Fatalf("Len() = %d, want 2", got)
+	}
+	if res := wi.Search("Alpha", 5); len(res) == 0 {
+		t.Errorf("Search(Alpha) returned no results from the static index")
+	}
+
+	// Close() must not block — WrapStatic pre-closes done (no watcher
+	// goroutine to wait on). A regression here would hang the cache's
+	// eviction path.
+	done := make(chan struct{})
+	go func() { _ = wi.Close(); close(done) }()
+	select {
+	case <-done:
+	default:
+		// Close should have completed synchronously; give the goroutine a
+		// scheduling beat before declaring a hang.
+		<-done
+	}
+
+	// SetExtraChunks on a static index is a guarded no-op: it must NOT
+	// rebuild from the (empty) live corpus, which would drop the loaded
+	// snapshot. Post-call, the original chunks must still be served.
+	wi.SetExtraChunks([]chunk.Chunk{
+		{File: "db.sql", StartLine: 1, EndLine: 1, Text: "CREATE TABLE t (id int);\n"},
+	})
+	if got := wi.Len(); got != 2 {
+		t.Errorf("after SetExtraChunks on static index: Len() = %d, want 2 (loaded snapshot must be preserved, extras ignored)", got)
+	}
+}


### PR DESCRIPTION
## Summary

A postgres+treesitter `ken-mcp` server hung on its first query during demo capture — three consecutive MCP `search` calls timed out at ~4 min and the server went unresponsive. **Reproduced + measured before fixing; both initially-suspected causes were ruled out:**

- **NOT a single-flight gap** — `mcp/cache.go` already uses `golang.org/x/sync/singleflight`. 3 concurrent cold searches → **one** build, all return at 44.26s. No spiral.
- **NOT watch-mode overhead** — `FromFS` 47.7s vs `NewWatchedIndex(watch=true)` 46.4s; first search 29ms; 621 dirs under a 1M FD limit.

**Real cause:** the `ken-mcp` *binary* always live-indexes the default repo on first query. ADR-024's pre-built-index auto-discovery existed only in the `mcp.Run` *library* — so the dev-loop binary (live-index) and the shipped `mcp.Run` binary (pre-built) had **silently diverged** on the cold-start path. A treesitter build of postgres is ~44s on a quiet machine; under capture-time contention (3 ken servers + the app on 16GB) that exceeded the MCP client's tool-call timeout.

## Fix — close the gap by giving the binary the same pre-built path

- **`search.WrapStatic(ix, root, mode, chunker)`** — wraps a loaded `*Index` in a non-watching `WatchedIndex`. `Close()` is a no-op (done pre-closed); `SetExtraChunks` is a guarded no-op so the DB-Tier-2 union-rebuild can't replace a static snapshot built from an empty live corpus.
- **`cmd/ken-mcp.loadOrBuildWatched`** — prefers `<repo>/.ken/index.bin` (ADR-024 convention) over a live build:
  - no pre-built file → live build + watcher (**unchanged**)
  - pre-built + mode/chunker **mismatch → hard error** (won't serve wrong-config results)
  - pre-built + corrupt/format/missing-model → **warn + live fallback** (slower-but-correct beats an outage)
- **Eager startup validation** — when `KEN_MCP_DEFAULT_REPO` carries a `.ken/index.bin`, load+validate at startup so a mismatch fails loudly (exit 1) and a success warms the cache. Repos with no pre-built index stay fully lazy (no startup build cost).

## Measured (real binary via `sdk.CommandTransport`, postgres+treesitter)

| scenario | result |
|---|---|
| first cold `search`, with `index.bin` | **46.6 ms** (was 44.6 s) — ~1000× |
| `chunker=regex` server vs treesitter `index.bin` | **exit 1** naming both sides + fix |
| `chunker=treesitter` server + treesitter `index.bin` | clean "loaded pre-built index … no watch" |
| no `index.bin` | live build + watcher (unchanged) |

**Second-order win:** the shipped demo binaries (`mcp.Run`, pre-built embedded index, no watch) now share the binary's startup path — less divergence between dev-loop and shipping.

## Calibration discipline

**Startup/transport only.** NOT a retrieval-quality / recall / ranking change, NOT a change to what gets indexed — a loaded pre-built index serves byte-identical chunks to what `ken build-index` produced for the same corpus + flags. Single-flight + watch-mode verified unchanged. Same framing as v0.8.3's "cold-start optimization, NOT search-quality change."

## Test plan

- [x] `go build ./...`, `go vet ./...`, `gofmt` clean
- [x] `go test ./...` green; `-race` green on `cmd/ken-mcp` + `internal/search` + `mcp`
- [x] `TestWrapStatic` (reads work, Close non-blocking, SetExtraChunks guard preserves snapshot)
- [x] `TestLoadOrBuild_NoPrebuilt_LiveBuilds` / `_Prebuilt_Matching_Loads` / `_Prebuilt_ChunkerMismatch_Errors`
- [x] `TestLocalPathHasPrebuilt`
- [x] End-to-end repro against the real binary (numbers above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)