### PR TITLE
fix(lint): errcheck on deferred wi.Close() in loadorbuild_test.go

### DIFF
--- a/cmd/ken-mcp/loadorbuild_test.go
+++ b/cmd/ken-mcp/loadorbuild_test.go
@@ -53,7 +53,7 @@ func TestLoadOrBuild_NoPrebuilt_LiveBuilds(t *testing.T) {
 	if err != nil {
 		t.Fatalf("loadOrBuildWatched: %v", err)
 	}
-	defer wi.Close()
+	defer func() { _ = wi.Close() }()
 	if wi.Len() == 0 {
 		t.Errorf("live build produced an empty index")
 	}
@@ -67,7 +67,7 @@ func TestLoadOrBuild_Prebuilt_Matching_Loads(t *testing.T) {
 	if err != nil {
 		t.Fatalf("loadOrBuildWatched: %v", err)
 	}
-	defer wi.Close()
+	defer func() { _ = wi.Close() }()
 	if wi.Len() == 0 {
 		t.Errorf("loaded pre-built index is empty")
 	}


### PR DESCRIPTION
## Summary

golangci-lint (errcheck) went red on main after PR #32: the v0.8.8 cold-start test had two `defer wi.Close()` calls that don't check the returned error.

```
Error: cmd/ken-mcp/loadorbuild_test.go:56:16: Error return value of `wi.Close` is not checked (errcheck)
Error: cmd/ken-mcp/loadorbuild_test.go:70:16: Error return value of `wi.Close` is not checked (errcheck)
```

Wrapped both as `defer func() { _ = wi.Close() }()`, matching the pattern already used in `wrapstatic_test.go`. Test-only; no behavior change.

## Test plan

- [x] `golangci-lint run ./cmd/ken-mcp/` → 0 issues
- [x] `golangci-lint run ./internal/search/` → 0 issues
- [x] `go test ./cmd/ken-mcp/` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)